### PR TITLE
[Fix]: 위젯 업데이트 에러

### DIFF
--- a/DontGoMart.xcodeproj/project.pbxproj
+++ b/DontGoMart.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		C359F5092CFDC16300F26B1D /* TwoHolidayWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C359F5072CFDC16300F26B1D /* TwoHolidayWidgetProvider.swift */; };
 		C3C2F8E82CEB18CE003ED9A5 /* MartModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2F8E72CEB18CE003ED9A5 /* MartModel.swift */; };
 		C3C2F8E92CEB18CE003ED9A5 /* MartModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2F8E72CEB18CE003ED9A5 /* MartModel.swift */; };
+		C3E71D7C2D2BFBBF00F4A24B /* Utillity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */; };
+		C3E71D7D2D2BFBBF00F4A24B /* Utillity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */; };
+		C3F7E7342D2CACF5003B7762 /* WidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -115,6 +118,8 @@
 		C359F5072CFDC16300F26B1D /* TwoHolidayWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoHolidayWidgetProvider.swift; sourceTree = "<group>"; };
 		C3C2F8E72CEB18CE003ED9A5 /* MartModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MartModel.swift; sourceTree = "<group>"; };
 		C3C2F8EE2CEB4952003ED9A5 /* DontGoMartTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DontGoMartTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utillity.swift; sourceTree = "<group>"; };
+		C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -152,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				589D5F482A433EFD00DB3CCF /* StoreKitManager.swift */,
+				C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -249,6 +255,7 @@
 		58D40ACF2CDF818B008C6458 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */,
 				58D40AD62CDF9130008C6458 /* Calendar+Ext.swift */,
 				58D40AD02CDF81A2008C6458 /* Date+Ext.swift */,
 				C359F4F22CFD8AD800F26B1D /* Color+Ext.swift */,
@@ -436,6 +443,7 @@
 				C359F5032CFDC0A800F26B1D /* HolidayWidgetProvider.swift in Sources */,
 				589D5F492A433EFD00DB3CCF /* StoreKitManager.swift in Sources */,
 				58B127DD2A3D3673004040EA /* ClosedDayCalendarView.swift in Sources */,
+				C3F7E7342D2CACF5003B7762 /* WidgetManager.swift in Sources */,
 				58D40AD12CDF81A5008C6458 /* Date+Ext.swift in Sources */,
 				58D40AD32CDF8E15008C6458 /* MartClosedData.swift in Sources */,
 				C359F5052CFDC14F00F26B1D /* DDayWidgetProvider.swift in Sources */,
@@ -445,6 +453,7 @@
 				C359F4F02CFD724000F26B1D /* WidgetDataMapper.swift in Sources */,
 				C359F5092CFDC16300F26B1D /* TwoHolidayWidgetProvider.swift in Sources */,
 				58B693F32A3B59EF00FF904B /* CalendarWidget.intentdefinition in Sources */,
+				C3E71D7C2D2BFBBF00F4A24B /* Utillity.swift in Sources */,
 				58B693D02A3B56E800FF904B /* DontGoMartApp.swift in Sources */,
 				58D40AD52CDF8E68008C6458 /* DateValue.swift in Sources */,
 			);
@@ -468,6 +477,7 @@
 				C304FA2A2D1D1B53000642C3 /* MartClosedData.swift in Sources */,
 				C3C2F8E92CEB18CE003ED9A5 /* MartModel.swift in Sources */,
 				58B693F22A3B59EF00FF904B /* CalendarWidget.intentdefinition in Sources */,
+				C3E71D7D2D2BFBBF00F4A24B /* Utillity.swift in Sources */,
 				58B693ED2A3B59EE00FF904B /* HolidayWidget.swift in Sources */,
 				C359F4F92CFD8FA700F26B1D /* DDayWidget.swift in Sources */,
 			);
@@ -618,10 +628,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = DontGoMart/DontGoMart.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DontGoMart/Preview Content\"";
-				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QGAQ3AY3R3;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -640,6 +653,8 @@
 				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.DontGoMart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dontGoMart;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -655,10 +670,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = DontGoMart/DontGoMart.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"DontGoMart/Preview Content\"";
-				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QGAQ3AY3R3;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -677,6 +695,8 @@
 				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.DontGoMart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = dontGoMart;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
@@ -692,9 +712,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = CalendarWidgetExtension.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QGAQ3AY3R3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DontGoMartWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CalendarWidget;
@@ -708,6 +730,8 @@
 				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.DontGoMart.CalendarWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = DontGoMartWidget;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -721,9 +745,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = CalendarWidgetExtension.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QGAQ3AY3R3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QGAQ3AY3R3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DontGoMartWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CalendarWidget;
@@ -737,6 +763,8 @@
 				MARKETING_VERSION = 1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.leeo.DontGoMart.CalendarWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = DontGoMartWidget;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/DontGoMart.xcodeproj/project.pbxproj
+++ b/DontGoMart.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		58D40AD52CDF8E68008C6458 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D40AD42CDF8E68008C6458 /* DateValue.swift */; };
 		58D40AD72CDF9138008C6458 /* Calendar+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D40AD62CDF9130008C6458 /* Calendar+Ext.swift */; };
 		58D40ADA2CDF9C92008C6458 /* Calendar+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D40AD62CDF9130008C6458 /* Calendar+Ext.swift */; };
+		C304FA2A2D1D1B53000642C3 /* MartClosedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D40AD22CDF8E15008C6458 /* MartClosedData.swift */; };
+		C304FA2B2D1D1B5A000642C3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D40AD42CDF8E68008C6458 /* DateValue.swift */; };
 		C359F4EF2CFD724000F26B1D /* WidgetDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C359F4EE2CFD724000F26B1D /* WidgetDataMapper.swift */; };
 		C359F4F02CFD724000F26B1D /* WidgetDataMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C359F4EE2CFD724000F26B1D /* WidgetDataMapper.swift */; };
 		C359F4F42CFD8AD800F26B1D /* Color+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C359F4F22CFD8AD800F26B1D /* Color+Ext.swift */; };
@@ -457,11 +459,13 @@
 				C359F5062CFDC14F00F26B1D /* DDayWidgetProvider.swift in Sources */,
 				58D40ADA2CDF9C92008C6458 /* Calendar+Ext.swift in Sources */,
 				C359F4F42CFD8AD800F26B1D /* Color+Ext.swift in Sources */,
+				C304FA2B2D1D1B5A000642C3 /* DateValue.swift in Sources */,
 				C359F4FD2CFD96CA00F26B1D /* TwoHolidayWidget.swift in Sources */,
 				58B693EB2A3B59EE00FF904B /* CalendarWidgetLiveActivity.swift in Sources */,
 				C359F5022CFDC0A800F26B1D /* HolidayWidgetProvider.swift in Sources */,
 				58B693E92A3B59EE00FF904B /* CalendarWidgetBundle.swift in Sources */,
 				C359F4EF2CFD724000F26B1D /* WidgetDataMapper.swift in Sources */,
+				C304FA2A2D1D1B53000642C3 /* MartClosedData.swift in Sources */,
 				C3C2F8E92CEB18CE003ED9A5 /* MartModel.swift in Sources */,
 				58B693F22A3B59EF00FF904B /* CalendarWidget.intentdefinition in Sources */,
 				58B693ED2A3B59EE00FF904B /* HolidayWidget.swift in Sources */,

--- a/DontGoMart.xcodeproj/project.pbxproj
+++ b/DontGoMart.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		58446A252A59390C001CC9D1 /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				58B127DC2A3D3673004040EA /* ClosedDayCalendarView.swift */,
 				58B693D12A3B56E800FF904B /* ClosedDaysView.swift */,
 				58446A272A59493C001CC9D1 /* SettingsView.swift */,
 			);
@@ -166,7 +167,6 @@
 		58446A262A593924001CC9D1 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				58B127DC2A3D3673004040EA /* ClosedDayCalendarView.swift */,
 				C3C2F8E72CEB18CE003ED9A5 /* MartModel.swift */,
 				58D40AD22CDF8E15008C6458 /* MartClosedData.swift */,
 				58D40AD42CDF8E68008C6458 /* DateValue.swift */,

--- a/DontGoMart.xcodeproj/xcuserdata/sukhyeonmacmini.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/DontGoMart.xcodeproj/xcuserdata/sukhyeonmacmini.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "A54E146E-A8A3-4C6E-9A96-C003ABF841E0"
+   type = "1"
+   version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "ADD0A348-9FF1-42B3-81F8-0E99A66D193E"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "DontGoMart/DontGoMartApp.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "54"
+            endingLineNumber = "54"
+            landmarkName = "body"
+            landmarkType = "24">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
+</Bucket>

--- a/DontGoMart.xcodeproj/xcuserdata/sukhyeonmacmini.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/DontGoMart.xcodeproj/xcuserdata/sukhyeonmacmini.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,22 +3,4 @@
    uuid = "A54E146E-A8A3-4C6E-9A96-C003ABF841E0"
    type = "1"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "ADD0A348-9FF1-42B3-81F8-0E99A66D193E"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "DontGoMart/DontGoMartApp.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "54"
-            endingLineNumber = "54"
-            landmarkName = "body"
-            landmarkType = "24">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 let year = Calendar.current.component(.year, from: Date())
-
+// let date = 이번 달 기준으로 데이터를 생성하는 함수
 @main
 struct DontGoMartApp: App {
     
@@ -16,84 +16,109 @@ struct DontGoMartApp: App {
         WindowGroup {
             ClosedDaysView()
                 .onAppear {
-                    tasks.append(contentsOf: generateBiweeklyTasks(
-                        forYear: year,
-                        weekdays: [
-                            (.sunday, .second, "2번째 일요일"),
-                            (.sunday, .fourth, "4번째 일요일")
-                        ],
-                        martType: .normal
-                    ))
-                    tasks.append(contentsOf: generateBiweeklyTasks(
-                        forYear: year,
-                        weekdays: [
-                            (.sunday, .second, "2번째 일요일"),
-                            (.sunday, .fourth, "4번째 일요일")
-                        ],
-                        martType: .costco(type: .normal)
-                    ))
-                    tasks.append(contentsOf: generateBiweeklyTasks(
-                        forYear: 2024,
-                        weekdays: [
-                            (.monday, .second, "2번째 월요일"),
-                            (.monday, .fourth, "4번째 월요일")
-                        ],
-                        martType: .costco(type: .daegu)
-                    ))
-                    tasks.append(contentsOf: generateBiweeklyTasks(
-                        forYear: 2024,
-                        weekdays: [
-                            (.wednesday, .second, "2번째 수요일"),
-                            (.wednesday, .fourth, "4번째 수요일")
-                        ],
-                        martType: .costco(type: .ilsan)
-                    ))
-                    tasks.append(contentsOf: generateBiweeklyTasks(
-                        forYear: 2024,
-                        weekdays: [
-                            (.wednesday, .second, "2번째 수요일"),
-                            (.sunday, .fourth, "4번째 일요일")
-                        ],
-                        martType: .costco(type: .ulsan)
-                    ))
+                    tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                    weekdays: [
+                        (.sunday, .second, "2번째 일요일"),
+                        (.sunday, .fourth, "4번째 일요일")
+                    ],
+                    martType: .normal
+                ))
+                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                    weekdays: [
+                        (.sunday, .second, "2번째 일요일"),
+                        (.sunday, .fourth, "4번째 일요일")
+                    ],
+                    martType: .costco(type: .normal)
+                ))
+                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                    weekdays: [
+                        (.monday, .second, "2번째 월요일"),
+                        (.monday, .fourth, "4번째 월요일")
+                    ],
+                    martType: .costco(type: .daegu)
+                ))
+                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                    weekdays: [
+                        (.wednesday, .second, "2번째 수요일"),
+                        (.wednesday, .fourth, "4번째 수요일")
+                    ],
+                    martType: .costco(type: .ilsan)
+                ))
+                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                    weekdays: [
+                        (.wednesday, .second, "2번째 수요일"),
+                        (.sunday, .fourth, "4번째 일요일")
+                    ],
+                    martType: .costco(type: .ulsan)
+                ))
                 }
         }
     }
-
+    
+    func getTasks() {
+        
+    }
+    
     private func generateBiweeklyTasks(
-            forYear year: Int,
-            monthRange: Range<Int> = 1..<13,
-            weekdays: [(Calendar.Weekday, Calendar.Ordinal, String)],
-            martType: MartType
-        ) -> [MetaMartsClosedDays] {
-            var tasks: [MetaMartsClosedDays] = []
-            let calendar = Calendar.current
-
-            // 각 달을 순회하면서 요일과 주차에 맞는 날짜를 찾음
-            for month in monthRange {
-                for (weekday, ordinal, title) in weekdays {
+        forYear year: Int,
+        monthRange: Range<Int> = 1..<13,
+        weekdays: [(Calendar.Weekday, Calendar.Ordinal, String)],
+        martType: MartType
+    ) -> [MetaMartsClosedDays] {
+        var tasks: [MetaMartsClosedDays] = []
+        let calendar = Calendar.current
+        
+        // 각 달을 순회하면서 요일과 주차에 맞는 날짜를 찾음
+        for month in monthRange {
+            for (weekday, ordinal, title) in weekdays {
+                if let date = findPatternDay(of: weekday, ordinal: ordinal, inMonth: month, year: year, calendar: calendar) {
+                    tasks.append(MetaMartsClosedDays(type: martType, task: [MartCloseData(title: title)], taskDate: date))
+                }
+            }
+        }
+        
+        return tasks
+    }
+    
+    private func modifiedGenerateBiweeklyTasks(
+        weekdays: [(Calendar.Weekday, Calendar.Ordinal, String)],
+        martType: MartType
+    ) -> [MetaMartsClosedDays] {
+        var tasks: [MetaMartsClosedDays] = []
+        let calendar = Calendar.current
+        
+        let year = calendar.component(.year, from: Date())
+        let month = calendar.component(.month, from: Date())
+        let previousMonth = (month == 1) ? (12, year - 1) : ((month - 1), year)
+        let nextMonth = (month == 12) ? (1, year + 1) : ((month + 1), year)
+        let range: [(Int, Int)] = [(previousMonth), (month, year), (nextMonth)]
+        print(range)
+        
+        // 각 달을 순회하면서 요일과 주차에 맞는 날짜를 찾음
+        for (month, year) in range {
+            for (weekday, ordinal, title) in weekdays {
                     if let date = findPatternDay(of: weekday, ordinal: ordinal, inMonth: month, year: year, calendar: calendar) {
                         tasks.append(MetaMartsClosedDays(type: martType, task: [MartCloseData(title: title)], taskDate: date))
                     }
-                }
             }
-
-            return tasks
         }
-
+        
+        return tasks
+    }
+    
     func findPatternDay(of weekday: Calendar.Weekday, ordinal: Calendar.Ordinal, inMonth month: Int, year: Int, calendar: Calendar) -> Date? {
         // 날짜 컴포넌트 설정
         var dateComponents = DateComponents(year: year, month: month)
-
+        
         // 해당 월의 첫 번째 날짜를 가져와서, 그 날이 어떤 요일인지 확인
         if let firstDayOfMonth = calendar.date(from: dateComponents) {
             let firstWeekday = calendar.component(.weekday, from: firstDayOfMonth)
             var targetDay = weekday.rawValue
-
+            
             // 첫 번째 날짜의 요일을 맞추기 위해 첫 번째 날을 이동
             let daysToAdd = (targetDay - firstWeekday + 7) % 7
             dateComponents.day = 1 + daysToAdd  // 첫 번째 목표 날짜로 설정
-
+            
             if let targetDate = calendar.date(from: dateComponents) {
                 // 두 번째, 네 번째 등 원하는 ordinal 번째 날짜 찾기
                 if ordinal == .first {

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 let year = Calendar.current.component(.year, from: Date())
-// let date = 이번 달 기준으로 데이터를 생성하는 함수
 @main
 struct DontGoMartApp: App {
     
@@ -17,40 +16,45 @@ struct DontGoMartApp: App {
             ClosedDaysView()
                 .onAppear {
                     tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
-                    weekdays: [
-                        (.sunday, .second, "2번째 일요일"),
-                        (.sunday, .fourth, "4번째 일요일")
-                    ],
-                    martType: .normal
-                ))
-                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
-                    weekdays: [
-                        (.sunday, .second, "2번째 일요일"),
-                        (.sunday, .fourth, "4번째 일요일")
-                    ],
-                    martType: .costco(type: .normal)
-                ))
-                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
-                    weekdays: [
-                        (.monday, .second, "2번째 월요일"),
-                        (.monday, .fourth, "4번째 월요일")
-                    ],
-                    martType: .costco(type: .daegu)
-                ))
-                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
-                    weekdays: [
-                        (.wednesday, .second, "2번째 수요일"),
-                        (.wednesday, .fourth, "4번째 수요일")
-                    ],
-                    martType: .costco(type: .ilsan)
-                ))
-                tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
-                    weekdays: [
-                        (.wednesday, .second, "2번째 수요일"),
-                        (.sunday, .fourth, "4번째 일요일")
-                    ],
-                    martType: .costco(type: .ulsan)
-                ))
+                        forYear: year,
+                        weekdays: [
+                            (.sunday, .second, "2번째 일요일"),
+                            (.sunday, .fourth, "4번째 일요일")
+                        ],
+                        martType: .normal
+                    ))
+                    tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                        forYear: year,
+                        weekdays: [
+                            (.sunday, .second, "2번째 일요일"),
+                            (.sunday, .fourth, "4번째 일요일")
+                        ],
+                        martType: .costco(type: .normal)
+                    ))
+                    tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                        forYear: year,
+                        weekdays: [
+                            (.monday, .second, "2번째 월요일"),
+                            (.monday, .fourth, "4번째 월요일")
+                        ],
+                        martType: .costco(type: .daegu)
+                    ))
+                    tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                        forYear: year,
+                        weekdays: [
+                            (.wednesday, .second, "2번째 수요일"),
+                            (.wednesday, .fourth, "4번째 수요일")
+                        ],
+                        martType: .costco(type: .ilsan)
+                    ))
+                    tasks.append(contentsOf: modifiedGenerateBiweeklyTasks(
+                        forYear: year,
+                        weekdays: [
+                            (.wednesday, .second, "2번째 수요일"),
+                            (.sunday, .fourth, "4번째 일요일")
+                        ],
+                        martType: .costco(type: .ulsan)
+                    ))
                 }
         }
     }
@@ -80,26 +84,25 @@ struct DontGoMartApp: App {
         return tasks
     }
     
-    private func modifiedGenerateBiweeklyTasks(
+    func modifiedGenerateBiweeklyTasks(
+        forYear year: Int,
+        monthRange: Range<Int> = 1..<13,
         weekdays: [(Calendar.Weekday, Calendar.Ordinal, String)],
         martType: MartType
     ) -> [MetaMartsClosedDays] {
         var tasks: [MetaMartsClosedDays] = []
         let calendar = Calendar.current
         
-        let year = calendar.component(.year, from: Date())
-        let month = calendar.component(.month, from: Date())
-        let previousMonth = (month == 1) ? (12, year - 1) : ((month - 1), year)
-        let nextMonth = (month == 12) ? (1, year + 1) : ((month + 1), year)
-        let range: [(Int, Int)] = [(previousMonth), (month, year), (nextMonth)]
-        print(range)
-        
+        let yearRange = [year - 1, year, year + 1]
         // 각 달을 순회하면서 요일과 주차에 맞는 날짜를 찾음
-        for (month, year) in range {
-            for (weekday, ordinal, title) in weekdays {
+        for year in yearRange {
+            print("\(year) Task Generate")
+            for month in monthRange {
+                for (weekday, ordinal, title) in weekdays {
                     if let date = findPatternDay(of: weekday, ordinal: ordinal, inMonth: month, year: year, calendar: calendar) {
                         tasks.append(MetaMartsClosedDays(type: martType, task: [MartCloseData(title: title)], taskDate: date))
                     }
+                }
             }
         }
         

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -58,11 +58,7 @@ struct DontGoMartApp: App {
                 }
         }
     }
-    
-    func getTasks() {
-        
-    }
-    
+
     private func generateBiweeklyTasks(
         forYear year: Int,
         monthRange: Range<Int> = 1..<13,
@@ -96,7 +92,7 @@ struct DontGoMartApp: App {
         let yearRange = [year - 1, year, year + 1]
         // 각 달을 순회하면서 요일과 주차에 맞는 날짜를 찾음
         for year in yearRange {
-            print("\(year) Task Generate")
+            print("\(year) - \(martType) Task Generate")
             for month in monthRange {
                 for (weekday, ordinal, title) in weekdays {
                     if let date = findPatternDay(of: weekday, ordinal: ordinal, inMonth: month, year: year, calendar: calendar) {

--- a/DontGoMart/Manager/WidgetManager.swift
+++ b/DontGoMart/Manager/WidgetManager.swift
@@ -1,0 +1,96 @@
+//
+//  WidgetManager.swift
+//  DontGoMart
+//
+//  Created by 황석현 on 1/7/25.
+//
+
+import SwiftUI
+import WidgetKit
+
+class WidgetManager {
+    static let shared = WidgetManager()
+    private init() {}
+    
+    func reloadWidget() {
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+    
+    func holidayText() {
+        var isNormal: Bool {
+            UserDefaults(suiteName: Utillity.appGroupId)?.bool(forKey: AppStorageKeys.isNormal) ?? true
+        }
+        
+        var selectedBranch: Int {
+            UserDefaults(suiteName: Utillity.appGroupId)?.integer(forKey: AppStorageKeys.selectedBranch) ?? 1
+        }
+        print("함수 내 selectedBranch: \(selectedBranch)")
+        print("함수 내 isNormal: \(isNormal)")
+        
+        var selectedMartType: MartType = .normal
+        let calendar = Calendar.current
+        let entryDate = calendar.startOfDay(for: Date())
+        
+        print("======================")
+        
+        // 마트 유형 설정
+        if selectedBranch == 0 {
+            selectedMartType = .normal
+        } else {
+            switch selectedBranch {
+            case 1: selectedMartType = .costco(type: .normal)
+            case 2: selectedMartType = .costco(type: .daegu)
+            case 3: selectedMartType = .costco(type: .ilsan)
+            case 4: selectedMartType = .costco(type: .ulsan)
+            default:
+                print("Wrong MartType")
+                return
+            }
+        }
+        
+        // 가장 가까운 휴일 찾기
+        print("함수 내 selectedMartType: \(selectedMartType)")
+        let costcoHolidays = tasks.filter { $0.type == selectedMartType }
+        
+        // 가장 가까운 휴일 필터링
+        let nextHoliday = costcoHolidays
+            .filter { $0.taskDate >= entryDate } // 오늘 이후의 휴일만 필터링
+            .sorted { $0.taskDate < $1.taskDate } // 날짜순 정렬
+            .first // 가장 가까운 휴일 선택
+        
+        guard let nextHolidayDate = nextHoliday?.taskDate else {
+            print("No upcoming holidays found")
+            return
+        }
+        
+        // 날짜 차이 계산
+        let daysDifference = calendar.dateComponents([.day], from: entryDate, to: nextHolidayDate).day ?? -1
+        print("daysDifference:", daysDifference)
+        print("entryDate:", entryDate)
+        print("nextHolidayDate:", nextHolidayDate)
+        
+        // UserDefaults에 텍스트 저장
+        switch daysDifference {
+        case 0:
+            UserDefaults(suiteName: Utillity.appGroupId)?.set("돈꼬 \(selectedMartType.widgetDisplayName)", forKey: AppStorageKeys.widgetHolidayText)
+        case 1:
+            UserDefaults(suiteName: Utillity.appGroupId)?.set("내일 돈꼬 \(selectedMartType.widgetDisplayName)", forKey: AppStorageKeys.widgetHolidayText)
+        case 2...6:
+            let dayText: String
+            switch selectedMartType {
+            case .costco(type: .daegu): dayText = "월요일"
+            case .costco(type: .ilsan): dayText = "수요일"
+            case .costco(type: .ulsan): dayText = "곧"
+            default: dayText = "이번 주"
+            }
+            UserDefaults(suiteName: Utillity.appGroupId)?.set("\(dayText) 돈꼬 \(selectedMartType.widgetDisplayName)", forKey: AppStorageKeys.widgetHolidayText)
+        default:
+            UserDefaults(suiteName: Utillity.appGroupId)?.set("꼬 \(selectedMartType.widgetDisplayName)", forKey: AppStorageKeys.widgetHolidayText)
+            print("No relevant holiday text found")
+        }
+        
+        self.reloadWidget()
+        print("Widget Update Success")
+    }
+    
+}

--- a/DontGoMart/Model/MartClosedData.swift
+++ b/DontGoMart/Model/MartClosedData.swift
@@ -18,5 +18,3 @@ struct MartCloseData: Identifiable {
     var id = UUID().uuidString
     var title: String
 }
-
-var tasks: [MetaMartsClosedDays] = []

--- a/DontGoMart/Model/MartModel.swift
+++ b/DontGoMart/Model/MartModel.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import WidgetKit
 
+var tasks: [MetaMartsClosedDays] = []
+
 enum MartType: Hashable {
     case normal
     case costco(type: CostcoBranch)
@@ -76,7 +78,7 @@ enum CostcoBranch: Hashable, Codable, CaseIterable {
 
 struct MartHoliday: Hashable, Identifiable {
     let id: UUID = UUID()
+    let type: MartType
     let month: Int
     let day: Int
-    let martType: MartType
 }

--- a/DontGoMart/Screen/ClosedDayCalendarView.swift
+++ b/DontGoMart/Screen/ClosedDayCalendarView.swift
@@ -186,7 +186,7 @@ struct ClosedDayCalendarView: View {
         return calendar.isDate(date1, inSameDayAs: date2)
     }
     
-    // extrating Year And Month for display...
+    /// extrating Year And Month for display...
     func extraDate()->[String]{
         
         var calendar = Calendar.current

--- a/DontGoMart/Screen/SettingsView.swift
+++ b/DontGoMart/Screen/SettingsView.swift
@@ -22,7 +22,7 @@ struct SettingsView: View {
                     })
                     .onChange(of: isCostco) {
                         selectedBranch = isCostco ? 1 : 0
-                        WidgetCenter.shared.reloadAllTimelines()
+                        WidgetManager.shared.holidayText()
                     }
                     NavigationLink {
                         CostcoSettings()

--- a/DontGoMart/Utilities/Utillity.swift
+++ b/DontGoMart/Utilities/Utillity.swift
@@ -1,0 +1,22 @@
+//
+//  Utillity.swift
+//  DontGoMart
+//
+//  Created by 황석현 on 1/6/25.
+//
+
+import Foundation
+
+enum Utillity {
+    static let primuimAppName = "돈꼬마트 pro"
+    static let appName = "돈꼬마트"
+    static let restorePurchases = "구매복원"
+    static let appGroupId = "group.com.leeo.DontGoMart"
+}
+
+enum AppStorageKeys {
+    static let selectedBranch = "selectedBranch"
+    static let isNormal = "isNormal"
+    static let isPremium = "isPremium"
+    static let widgetHolidayText = "widgetHolidayText"
+}

--- a/DontGoMartWidget/Utilities/WidgetDataMapper.swift
+++ b/DontGoMartWidget/Utilities/WidgetDataMapper.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 import WidgetKit
 
+struct HolidayEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationIntent
+    let holidayText: String
+}
+
 struct DayEntry: TimelineEntry {
     let date: Date
     let configuration: ConfigurationIntent

--- a/DontGoMartWidget/Utilities/WidgetDataMapper.swift
+++ b/DontGoMartWidget/Utilities/WidgetDataMapper.swift
@@ -19,28 +19,29 @@ class WidgetDataMapper {
     
     // 마트 휴일 생성 (일반 마트, 코스트코 휴일 데이터)
     func createMartHolidays() {
+        print("createMartHolidays")
         data = []
-        
-        let weekday = Calendar.Weekday.sunday
-        data += generateMartHolidays(forYear: year, weekday: .sunday, nth: 2, martType: .normal)
-        data += generateMartHolidays(forYear: year, weekday: .sunday, nth: 4, martType: .normal)
-        
-        
-        data += generateMartHolidays(forYear: year, weekday: .monday, nth: 2, martType: .costco(type: .daegu))
-        data += generateMartHolidays(forYear: year, weekday: .monday, nth: 4, martType: .costco(type: .daegu))
-        
-        
-        data += generateMartHolidays(forYear: year, weekday: .wednesday, nth: 2, martType: .costco(type: .ilsan))
-        data += generateMartHolidays(forYear: year, weekday: .wednesday, nth: 4, martType: .costco(type: .ilsan))
-        
-        
-        data += generateMartHolidays(forYear: year, weekday: .wednesday, nth: 2, martType: .costco(type: .ulsan))
-        data += generateMartHolidays(forYear: year, weekday: .sunday, nth: 4, martType: .costco(type: .ulsan))
+        data += modifiedGenerateMartHolidays()
     }
     
     
+    func modifiedGenerateMartHolidays() -> [MartHoliday] {
+        let calendar = Calendar.current
+        var holidays: [MartHoliday] = []
+        
+        for task in tasks {
+            let month = calendar.component(.month, from: task.taskDate)
+            let day = calendar.component(.day, from: task.taskDate)
+            let holiday = MartHoliday(type: task.type, month: month, day: day)
+            holidays.append(holiday)
+        }
+        
+        return holidays
+    }
+    
     // N번째 특정 요일에 따른 MartHoliday 배열 생성 함수
     func generateMartHolidays(forYear year: Int, weekday: Calendar.Weekday, nth: Int, martType: MartType) -> [MartHoliday] {
+        // n번째 요일을 저장
         let dates = nthWeekdayOfYear(forYear: year, weekday: weekday, nth: nth)
         var holidays: [MartHoliday] = []
         let calendar = Calendar.current
@@ -48,7 +49,7 @@ class WidgetDataMapper {
         for (monthIndex, date) in dates.enumerated() {
             if let date = date {
                 let day = calendar.component(.day, from: date)
-                let holiday = MartHoliday(month: monthIndex + 1, day: day, martType: martType)
+                let holiday = MartHoliday(type: martType, month: monthIndex + 1, day: day)
                 holidays.append(holiday)
             }
         }
@@ -85,6 +86,7 @@ class WidgetDataMapper {
         var dates: [Date?] = []
         
         for month in 1...12 {
+            // 한 달에 N번쨰 특정 요일을 찾는 함수
             if let nthWeekdayDate = nthWeekday(forYear: year, month: month, weekday: weekday, nth: nth) {
                 dates.append(nthWeekdayDate)
             } else {
@@ -97,12 +99,12 @@ class WidgetDataMapper {
     
     // MartHoliday 타입의 데이터를 초기화하는 함수 정의
     func createMartHolidays(monthDayPairs: [(Int, Int)], martType: MartType) -> [MartHoliday] {
-        return monthDayPairs.map { MartHoliday(month: $0.0, day: $0.1, martType: martType) }
+        return monthDayPairs.map { MartHoliday(type: martType, month: $0.0, day: $0.1) }
     }
     
     func holidayText(selectedMartType: MartType, entryDate: Date) -> (text: String, color: Color)? {
-        let costcoHolidays = data.filter { $0.martType == selectedMartType }
         print("======================")
+        let costcoHolidays = data.filter { $0.type == selectedMartType }
         for datum in costcoHolidays {
             print(costcoHolidays)
 
@@ -113,7 +115,7 @@ class WidgetDataMapper {
             let formattedDate = dateFormatter.string(from: displayDate)
             let finalDate = dateFormatter.date(from: formattedDate)!
             
-            guard datum.martType == selectedMartType else { return nil }
+            guard datum.type == selectedMartType else { return nil }
                         
             // daysDifference 계산
             if let daysDifference = Calendar.current.dateComponents([.day], from: entryDate, to: finalDate).day {
@@ -125,7 +127,7 @@ class WidgetDataMapper {
                 case 1:
                     print("1")
                     return ("내일 돈꼬 \(selectedMartType.widgetDisplayName)", .palePink)
-                case 2...6:
+                case 2...20:
                     print("2")
                     let dayText: String
                     switch selectedMartType {
@@ -138,7 +140,7 @@ class WidgetDataMapper {
                 default:
                     continue
                 }
-            }
+            } else { print("DaysDifference Error")}
         }
         
         

--- a/DontGoMartWidget/Widget/DDayWidget.swift
+++ b/DontGoMartWidget/Widget/DDayWidget.swift
@@ -10,8 +10,8 @@ import WidgetKit
 
 // TODO: 2개의 휴일을 보여준다
 struct DDayWidgetEntryView: View {
-    @AppStorage("isNormal", store: UserDefaults(suiteName: appGroupId)) var isCostco: Bool = false
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
+    @AppStorage("isNormal", store: UserDefaults(suiteName: Utillity.appGroupId)) var isCostco: Bool = false
+    @AppStorage("selectedBranch", store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
     @State private var selectedMartType: MartType = .normal
     
     var entry: DayEntry

--- a/DontGoMartWidget/Widget/HolidayWidget.swift
+++ b/DontGoMartWidget/Widget/HolidayWidget.swift
@@ -45,7 +45,7 @@ struct HolidayWidgetEntryView : View {
                     .foregroundColor(holiday.color)
                     .multilineTextAlignment(.center)
                     .onChange(of: selectedBranch) {
-                        WidgetCenter.shared.reloadTimelines(ofKind: "MonthlyWidget")
+                        WidgetCenter.shared.reloadTimelines(ofKind: "HolidayWidget")
                         WidgetCenter.shared.reloadAllTimelines()
                     }
             }

--- a/DontGoMartWidget/Widget/HolidayWidget.swift
+++ b/DontGoMartWidget/Widget/HolidayWidget.swift
@@ -9,26 +9,16 @@ import WidgetKit
 import SwiftUI
 import Intents
 
-
-
-let appGroupId = "group.com.leeo.DontGoMart"
-
-// TODO: 현재 날짜가 아닌 휴일까지의 날짜를 보여준다
 struct HolidayWidgetEntryView : View {
-    @AppStorage("isNormal", store: UserDefaults(suiteName: appGroupId)) var isCostco: Bool = false
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
+    @AppStorage("isNormal", store: UserDefaults(suiteName: Utillity.appGroupId)) var isCostco: Bool = false
+    @AppStorage("selectedBranch", store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
     @State private var selectedMartType: MartType = .normal
     
-    var entry: DayEntry
+    var entry: HolidayEntry
     var config: MonthConfig
     var widgetDataMapper: WidgetDataMapper
 
-    // 기본 마트 휴일 목록 정의
-    
-    // 오늘 날짜로부터 2025년까지의 모든 둘째, 넷째 주 일요일 찾기
-    let startDate = Date()
-
-    init(entry: DayEntry) {
+    init(entry: HolidayEntry) {
         self.entry = entry
         self.config = MonthConfig.determineConfig(from: entry.date)
         self.widgetDataMapper = WidgetDataMapper()
@@ -36,20 +26,17 @@ struct HolidayWidgetEntryView : View {
     
     var body: some View {
         VStack {
-            // ForEach 구문
-            if let holiday = widgetDataMapper.holidayText(selectedMartType: selectedMartType, entryDate: Date()) {
-                Text(holiday.text)
+            Text(entry.holidayText)
                     .font(.title3)
                     .fontWeight(.bold)
                     .minimumScaleFactor(0.6)
-                    .foregroundColor(holiday.color)
+                    .foregroundColor(.red)
                     .multilineTextAlignment(.center)
                     .onChange(of: selectedBranch) {
                         widgetDataMapper.createMartHolidays()
                         WidgetCenter.shared.reloadTimelines(ofKind: "HolidayWidget")
                         WidgetCenter.shared.reloadAllTimelines()
                     }
-            }
         
             
             HStack(spacing: 0) {
@@ -105,7 +92,7 @@ struct HolidayWidget: Widget {
 
 struct CalendarWidget_Previews: PreviewProvider {
     static var previews: some View {
-        HolidayWidgetEntryView(entry: DayEntry(date: dateToDisplay(month: 12, day: 31), configuration: ConfigurationIntent()))
+        HolidayWidgetEntryView(entry: HolidayEntry(date: dateToDisplay(month: 12, day: 31), configuration: ConfigurationIntent(), holidayText: "Preview"))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
     }
     

--- a/DontGoMartWidget/Widget/HolidayWidget.swift
+++ b/DontGoMartWidget/Widget/HolidayWidget.swift
@@ -45,6 +45,7 @@ struct HolidayWidgetEntryView : View {
                     .foregroundColor(holiday.color)
                     .multilineTextAlignment(.center)
                     .onChange(of: selectedBranch) {
+                        widgetDataMapper.createMartHolidays()
                         WidgetCenter.shared.reloadTimelines(ofKind: "HolidayWidget")
                         WidgetCenter.shared.reloadAllTimelines()
                     }
@@ -104,7 +105,7 @@ struct HolidayWidget: Widget {
 
 struct CalendarWidget_Previews: PreviewProvider {
     static var previews: some View {
-        HolidayWidgetEntryView(entry: DayEntry(date: dateToDisplay(month: 7, day: 5), configuration: ConfigurationIntent()))
+        HolidayWidgetEntryView(entry: DayEntry(date: dateToDisplay(month: 12, day: 31), configuration: ConfigurationIntent()))
             .previewContext(WidgetPreviewContext(family: .systemSmall))
     }
     

--- a/DontGoMartWidget/Widget/Provider/HolidayWidgetProvider.swift
+++ b/DontGoMartWidget/Widget/Provider/HolidayWidgetProvider.swift
@@ -6,26 +6,29 @@
 //
 
 import WidgetKit
+import SwiftUI
 
 struct HolidayWidgetProvider: IntentTimelineProvider {
-    func placeholder(in context: Context) -> DayEntry {
-        DayEntry(date: Date(), configuration: ConfigurationIntent())
+    func placeholder(in context: Context) -> HolidayEntry {
+        HolidayEntry(date: Date(), configuration: ConfigurationIntent(), holidayText: "내일 돈꼬")
     }
     
-    func getSnapshot(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (DayEntry) -> ()) {
-        let entry = DayEntry(date: Date(), configuration: configuration)
+    func getSnapshot(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (HolidayEntry) -> ()) {
+        let entry = HolidayEntry(date: Date(), configuration: configuration, holidayText: "내일 돈꼬")
         completion(entry)
     }
     
-    func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<DayEntry>) -> ()) {
+    func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<HolidayEntry>) -> ()) {
         print("HolidayWidget getTimeline()")
-        var entries: [DayEntry] = []
+        var entries: [HolidayEntry] = []
+        @AppStorage(AppStorageKeys.widgetHolidayText, store: UserDefaults(suiteName: Utillity.appGroupId))
+        var holidayText: String = ""
         
         let currentDate = Date()
         for dayOffset in 0 ..< 7 {
             let entryDate = Calendar.current.date(byAdding: .day, value: dayOffset, to: currentDate)!
             let startOfDate = Calendar.current.startOfDay(for: entryDate)
-            let entry = DayEntry(date: startOfDate, configuration: configuration)
+            let entry = HolidayEntry(date: startOfDate, configuration: configuration, holidayText: holidayText)
             entries.append(entry)
         }
         

--- a/DontGoMartWidget/Widget/Provider/HolidayWidgetProvider.swift
+++ b/DontGoMartWidget/Widget/Provider/HolidayWidgetProvider.swift
@@ -18,6 +18,7 @@ struct HolidayWidgetProvider: IntentTimelineProvider {
     }
     
     func getTimeline(for configuration: ConfigurationIntent, in context: Context, completion: @escaping (Timeline<DayEntry>) -> ()) {
+        print("HolidayWidget getTimeline()")
         var entries: [DayEntry] = []
         
         let currentDate = Date()

--- a/DontGoMartWidget/Widget/TwoHolidayWidget.swift
+++ b/DontGoMartWidget/Widget/TwoHolidayWidget.swift
@@ -10,8 +10,8 @@ import WidgetKit
 
 // TODO: 두 지점의 휴일을 보여준다
 struct TwoHolidayEntryView: View {
-    @AppStorage("isNormal", store: UserDefaults(suiteName: appGroupId)) var isCostco: Bool = false
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
+    @AppStorage("isNormal", store: UserDefaults(suiteName: Utillity.appGroupId)) var isCostco: Bool = false
+    @AppStorage("selectedBranch", store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
     @State private var selectedMartType: MartType = .normal
     
     var entry: DayEntry


### PR DESCRIPTION
## 변경사항

1. 위젯에서 휴일 정보를 생성 
-> 앱에서 위젯에서 표시할 `String`데이터 생성 후 `AppGroup`으로 공유된 저장소에 저장

2. 앱에서 `WidgetCenter.shared.reloadAllTimelines()` 호출 시, 위젯에서 표시할 데이터 초기화
-> 앱에서 데이터 초기화하면 `WidgetCenter.shared.reloadAllTimelines()` 호출하여 위젯에서는 단순 문자열만 표시

3. 휴일이 6일이상 남으면 날짜만 보여줌
-> 휴일이 6일이상 남으면 `꼬 코스트코` 문자를 위젯에 표시

4. "group.com.leeo.DontGoMart"를 appID로 초기화하여 사용
-> 위젯과 앱에서 공통적으로 사용하는 값을 `Utility.swift`에 `enum`으로 정의하여 사용
```swift
enum Utillity {
    static let primuimAppName = "돈꼬마트 pro"
    static let appName = "돈꼬마트"
    static let restorePurchases = "구매복원"
    static let appGroupId = "group.com.leeo.DontGoMart"
}

enum AppStorageKeys {
    static let selectedBranch = "selectedBranch"
    static let isNormal = "isNormal"
    static let isPremium = "isPremium"
    static let widgetHolidayText = "widgetHolidayText"
}
```

5. 내년 휴일이 보이지 않음.
-> 올해 기준 앞뒤 1년씩의 데이터를 생성하여 오류 해결

<div>
<img width="300" src="https://github.com/user-attachments/assets/f121483a-cd55-4cd7-b639-1f20d2007396">
</div>

close #9
close #11