### PR TITLE
fix: 위젯 초기값 할당

### DIFF
--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -55,6 +55,7 @@ struct DontGoMartApp: App {
                         ],
                         martType: .costco(type: .ulsan)
                     ))
+                    WidgetManager.shared.updateWidget()
                 }
         }
     }

--- a/DontGoMart/Manager/WidgetManager.swift
+++ b/DontGoMart/Manager/WidgetManager.swift
@@ -17,31 +17,29 @@ class WidgetManager {
     }
     
     func updateWidget() {
-        twoHolidayText()
-        holidayText()
-        reloadWidget()
+        let isNormal = UserDefaults(suiteName: Utillity.appGroupId)?.bool(forKey: AppStorageKeys.isCostco) ?? true
+        let selectedBranch = UserDefaults(suiteName: Utillity.appGroupId)?.integer(forKey: AppStorageKeys.selectedBranch) ?? 0
+        
+        print("updateWidget : isNormal(\(isNormal)), selectedBranch(\(selectedBranch))")
+        self.holidayText(isCostco: isNormal, selectedBranch: selectedBranch)
+        self.twoHolidayText(isCostco: isNormal, selectedBranch: selectedBranch)
+        self.reloadWidget()
     }
     
-    func twoHolidayText() {
-        var isNormal: Bool {
-            UserDefaults(suiteName: Utillity.appGroupId)?.bool(forKey: AppStorageKeys.isNormal) ?? true
-        }
+    func twoHolidayText(isCostco: Bool, selectedBranch: Int) {
         
-        var selectedBranch: Int {
-            UserDefaults(suiteName: Utillity.appGroupId)?.integer(forKey: AppStorageKeys.selectedBranch) ?? 1
-        }
-        print("함수 내 selectedBranch: \(selectedBranch)")
-        print("함수 내 isNormal: \(isNormal)")
+        print("==========twoHolidayText===========")
+        print("함수 내 selectedBranch: \(String(describing: selectedBranch))")
+        print("함수 내 isNormal: \(String(describing: isCostco))")
         
         var selectedMartType: MartType = .normal
         let calendar = Calendar.current
         let entryDate = calendar.startOfDay(for: Date())
         
-        print("======================")
-        
         // 마트 유형 설정
-        if selectedBranch == 0 {
+        if selectedBranch == 0 || !isCostco {
             selectedMartType = .normal
+            UserDefaults(suiteName: Utillity.appGroupId)?.set(0, forKey: AppStorageKeys.selectedBranch)
         } else {
             switch selectedBranch {
             case 1: selectedMartType = .costco(type: .normal)
@@ -81,26 +79,20 @@ class WidgetManager {
         print("TwoHolidayText Update Success")
     }
     
-    func holidayText() {
-        var isNormal: Bool {
-            UserDefaults(suiteName: Utillity.appGroupId)?.bool(forKey: AppStorageKeys.isNormal) ?? true
-        }
+    func holidayText(isCostco: Bool, selectedBranch: Int) {
         
-        var selectedBranch: Int {
-            UserDefaults(suiteName: Utillity.appGroupId)?.integer(forKey: AppStorageKeys.selectedBranch) ?? 1
-        }
-        print("함수 내 selectedBranch: \(selectedBranch)")
-        print("함수 내 isNormal: \(isNormal)")
+        print("==========holidayText============")
+        print("함수 내 selectedBranch: \(String(describing: selectedBranch))")
+        print("함수 내 isNormal: \(String(describing: isCostco))")
         
         var selectedMartType: MartType = .normal
         let calendar = Calendar.current
         let entryDate = calendar.startOfDay(for: Date())
         
-        print("======================")
-        
         // 마트 유형 설정
-        if selectedBranch == 0 {
+        if selectedBranch == 0 || !isCostco {
             selectedMartType = .normal
+            UserDefaults(suiteName: Utillity.appGroupId)?.set(0, forKey: AppStorageKeys.selectedBranch)
         } else {
             switch selectedBranch {
             case 1: selectedMartType = .costco(type: .normal)

--- a/DontGoMart/Screen/ClosedDayCalendarView.swift
+++ b/DontGoMart/Screen/ClosedDayCalendarView.swift
@@ -11,8 +11,8 @@ struct ClosedDayCalendarView: View {
     @Binding var currentDate: Date
     @State var currentMonth: Int = 0
     @State var selectedMartType: MartType = .normal
-    @AppStorage("isNormal", store: UserDefaults(suiteName: appGroupId)) var isCostco: Bool = true
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
+    @AppStorage(AppStorageKeys.isCostco, store: UserDefaults(suiteName: Utillity.appGroupId)) var isCostco: Bool = true
+    @AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
     
     var body: some View {
         VStack(spacing: 35) {

--- a/DontGoMart/Screen/ClosedDaysView.swift
+++ b/DontGoMart/Screen/ClosedDaysView.swift
@@ -12,7 +12,6 @@ import WidgetKit
 let primuimAppName = "돈꼬마트 pro"
 let appName = "돈꼬마트"
 let restorePurchases = "구매복원"
-let appGroupId = "group.com.leeo.DontGoMart"
 
 struct ClosedDaysView: View {
     @State var currentDate: Date = Date()
@@ -20,7 +19,7 @@ struct ClosedDaysView: View {
     @AppStorage("isPremium") var isPremium: Bool = false
     @State private var isShowingSettings = false
     @State private var isCostco: Bool = false
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
+    @AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
     
     var body: some View {
         NavigationStack {
@@ -53,11 +52,11 @@ struct ClosedDaysView: View {
         }
         .onChange(of: selectedBranch) {
             print("selectedBranch: \(selectedBranch)")
-            WidgetCenter.shared.reloadAllTimelines()
+            WidgetManager.shared.updateWidget()
         }
         .sheet(isPresented: $isShowingSettings ,onDismiss: {
-            isCostco = UserDefaults(suiteName: appGroupId)?.bool(forKey: "isNormal") ?? false
-            selectedBranch = UserDefaults(suiteName: appGroupId)?.integer(forKey: "selectedBranch") ?? 0
+            isCostco = UserDefaults(suiteName: Utillity.appGroupId)?.bool(forKey: AppStorageKeys.isCostco) ?? false
+            selectedBranch = UserDefaults(suiteName: Utillity.appGroupId)?.integer(forKey: AppStorageKeys.selectedBranch) ?? 0
         }) {
             SettingsView(isShowingSettings: $isShowingSettings)
         }
@@ -123,7 +122,7 @@ struct SellItem: View {
 }
 
 class EntitlementManager: ObservableObject {
-    static let userDefaults = UserDefaults(suiteName: appGroupId)!
+    static let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)!
     
     @AppStorage("hasPro", store: userDefaults) var hasPro: Bool = false
 }

--- a/DontGoMart/Screen/SettingsView.swift
+++ b/DontGoMart/Screen/SettingsView.swift
@@ -10,8 +10,8 @@ import WidgetKit
 
 struct SettingsView: View {
     @Binding var isShowingSettings: Bool
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
-    @AppStorage("isNormal", store: UserDefaults(suiteName: appGroupId)) var isCostco: Bool = false
+    @AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
+    @AppStorage(AppStorageKeys.isCostco, store: UserDefaults(suiteName: Utillity.appGroupId)) var isCostco: Bool = false
     
     var body: some View {
         NavigationStack {
@@ -35,6 +35,7 @@ struct SettingsView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
+                        WidgetManager.shared.updateWidget()
                         isShowingSettings = false
                     }) {
                         Text("완료")
@@ -47,7 +48,7 @@ struct SettingsView: View {
 
 
 struct CostcoSettings: View {
-    @AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
+    @AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
     @State var selectedCostcoBranch: CostcoBranch = .normal
     
     var body: some View {

--- a/DontGoMart/Utilities/Utillity.swift
+++ b/DontGoMart/Utilities/Utillity.swift
@@ -16,7 +16,7 @@ enum Utillity {
 
 enum AppStorageKeys {
     static let selectedBranch = "selectedBranch"
-    static let isNormal = "isNormal"
+    static let isCostco = "isCostco"
     static let isPremium = "isPremium"
     static let widgetHolidayText = "widgetHolidayText"
     static let widgetTwoHolidayText = "widgetTwoHolidayText"

--- a/DontGoMartWidget/Widget/TwoHolidayWidget.swift
+++ b/DontGoMartWidget/Widget/TwoHolidayWidget.swift
@@ -25,6 +25,7 @@ struct TwoHolidayEntryView: View {
             Text(entry.holidayText[0])
                 .font(.title)
                 .fontWeight(.bold)
+                .minimumScaleFactor(0.5)
             Text(entry.holidayText[1])
                 .fontWeight(.bold)
                 .padding(.vertical, 10)


### PR DESCRIPTION
# 개요
- 위젯 초기값을 할당
- 마트타입 변경 시 위젯이 업데이트 되지 않는 현상 해결
- `isNormal = true`인데 코스트코 토글 활성화
- `isNormal` -> `isCostco` 로 변경

## 상세내용
### 앱 시작시 위젯 업데이트하기
문제 : 2개의 휴일을 보여주는 위젯이 마트를 변경하기 전까지 "데이터 없음"을 표시함   

원인 : 첫 앱 시작 시에는 해당 위젯에 초기값이 "데이터 없음"이기에 발생   

해결 : 앱 시작 시 휴일 데이터를 생성하듯 위젯 데이터도 생성   
```swift
WindowGroup {
            ClosedDaysView()
                .onAppear {
                    // 중략
                    WidgetManager.shared.updateWidget()
                }
```
### 마트 타입 변경 시 위젯이 업데이트 되지 않는 현상
문제 : 마트 타입을 변경해도 위젯에서는 "돈꼬 마트" 정보만 표시(일반 마트)

원인 : 마트 타입을 변경해도 위젯 업데이트 함수에서 잘못된 `branchID`를 불러옴
(예: 선택한 `branchID = 3`, 불러온 `branchID = 0`)

해결 : 동일한 appGroupID를 사용하고 있지 않았음.
```swift
// 수정 전 코드
@AppStorage("selectedBranch", store: UserDefaults(suiteName: appGroupId)) var selectedBranch: Int = 0
```
```swift
// 수정 후 코드
@AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
```
### `isNormal` -> `isCostco` 로 변경
문제 : `isNormal = true`라면 코스트코 토글이 비활성화 되어야하는데 활성화 되어있음

원인 : 토글은 `isCostco` 라는 프로퍼티를 기준으로 동작하는데 `isCostco`는 `isNormal`로 초기화되고 있음
따라서, 전혀 반대되는 `Boolean` 값으로 초기화되고 있고 토글이 이를 표시하고 있는 것.

해결 : `isNormal`이 아닌 `isCostco`로 변경하여 사용
```swift
@AppStorage(AppStorageKeys.isCostco, store: UserDefaults(suiteName: Utillity.appGroupId)) var isCostco: Bool = false
```
