### PR TITLE
feat: 푸쉬 알람 예약하기

### DIFF
--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -55,7 +55,38 @@ struct DontGoMartApp: App {
                         martType: .costco(type: .ulsan)
                     ))
                     WidgetManager.shared.updateWidget()
+                    
+                    Task {
+                        await setupSmartNotifications()
+                    }
                 }
+        }
+    }
+    
+    /// 스마트 알림 초기 설정 (사용자 설정 고려)
+    private func setupSmartNotifications() async {
+        let notificationManager = NotificationManager.shared
+        
+        // 사용자가 알림을 활성화했는지 확인
+        let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
+        let isNotificationEnabled = userDefaults?.bool(forKey: AppStorageKeys.notificationEnabled) ?? false
+        
+        guard isNotificationEnabled else {
+            print("🔕 사용자가 알림을 비활성화했으므로 알림을 설정하지 않습니다.")
+            return
+        }
+        
+        // 권한 상태 확인
+        let status = await notificationManager.checkAuthorizationStatus()
+        
+        if status == .authorized {
+            // 이미 권한이 있으면 바로 알림 설정
+            await notificationManager.setupSmartNotifications(for: tasks)
+        } else if status == .notDetermined {
+            // 권한이 결정되지 않았으면 요청 (사용자가 직접 설정에서 켤 때까지 대기)
+            print("⏳ 알림 권한이 결정되지 않았습니다. 설정에서 알림을 활성화해주세요.")
+        } else {
+            print("❌ 알림 권한이 거부되었습니다. 설정에서 권한을 허용해주세요.")
         }
     }
 

--- a/DontGoMart/Manager/NotificationManager.swift
+++ b/DontGoMart/Manager/NotificationManager.swift
@@ -1,0 +1,319 @@
+import SwiftUI
+import UserNotifications
+
+final class NotificationManager {
+    static let shared = NotificationManager()
+    private init() {}
+    
+    // MARK: - 상수 정의
+    
+    private enum Constants {
+        /// iOS 알림 제한 안전 임계값 (실제 제한: 64개)
+        static let maxSafeNotificationCount = 60
+    }
+    
+    // MARK: - 알림 설정 변수들
+    
+    /// 첫 번째 알림: 며칠 전에 보낼지 (기본: 3일 전)
+    static var firstNotificationDaysBefore: Int = 3
+    /// 두 번째 알림: 며칠 전에 보낼지 (기본: 1일 전)
+    static var secondNotificationDaysBefore: Int = 1
+    /// 알림 시간: 시 (24시간 형식)
+    static var notificationHour: Int = 21
+    /// 알림 분
+    static var notificationMinute: Int = 0
+    /// 알림 설정할 최대 일수 (앞으로 90일)
+    static let maxNotificationDays: Int = 90
+    
+    // MARK: - 알림 타입
+    
+    enum NotificationType: String, CaseIterable {
+        case firstNotification = "day1_before"
+        case secondNotification = "day2_before"
+        
+        var title: String {
+            switch self {
+            case .firstNotification:
+                return "마트 휴무일 안내"
+            case .secondNotification:
+                return "마트 휴무일 안내"
+            }
+        }
+        
+        func body(for martType: MartType) -> String {
+            let storeName = martType.notificationStoreName
+            switch self {
+            case .firstNotification:
+                return "\(NotificationManager.firstNotificationDaysBefore)일 뒤 \(storeName) 휴점일입니다."
+            case .secondNotification:
+                return "\(NotificationManager.secondNotificationDaysBefore)일 뒤 \(storeName) 휴점일입니다."
+            }
+        }
+        
+        var daysToSubtract: Int {
+            switch self {
+            case .firstNotification:
+                return NotificationManager.firstNotificationDaysBefore
+            case .secondNotification:
+                return NotificationManager.secondNotificationDaysBefore
+            }
+        }
+    }
+    
+    // MARK: - 권한 관리
+    
+    /// 알림 권한 요청
+    func requestAuthorization() async -> Bool {
+        do {
+            let authorized = try await UNUserNotificationCenter.current().requestAuthorization(
+                options: [.alert, .sound, .badge]
+            )
+            
+            if authorized {
+                print("✅ 알림 권한이 허용되었습니다.")
+            } else {
+                print("❌ 알림 권한이 거부되었습니다.")
+            }
+            
+            return authorized
+        } catch {
+            print("❌ 알림 권한 요청 중 오류: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    /// 현재 알림 권한 상태 확인
+    func checkAuthorizationStatus() async -> UNAuthorizationStatus {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        return settings.authorizationStatus
+    }
+    
+
+    
+    // MARK: - 핵심 알림 설정 로직
+    
+    /// 사용자 선택 매장의 가까운 미래 휴무일에 대해서만 알림 설정 (iOS 64개 제한 고려)
+    func setupSmartNotifications(for allTasks: [MetaMartsClosedDays]) async {
+        
+        // 1. 사전 조건 확인
+        guard await validateNotificationPrerequisites() else { return }
+        
+        // 2. 기존 알림 정리
+        clearExistingNotifications()
+        
+        // 3. 알림 대상 필터링
+        let targetTasks = await filterNotificationTargets(from: allTasks)
+        
+        // 4. 알림 스케줄링 실행
+        let scheduledCount = await scheduleNotificationsForTasks(targetTasks)
+        
+        // 5. 결과 검증 및 로깅
+        await validateAndLogResults(scheduledCount: scheduledCount)
+    }
+    
+    // MARK: - 알림 설정 단계별 메서드
+    
+    /// 1단계: 알림 설정 사전 조건 확인
+    private func validateNotificationPrerequisites() async -> Bool {
+        // 사용자 알림 설정 확인
+        let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
+        let isNotificationEnabled = userDefaults?.bool(forKey: AppStorageKeys.notificationEnabled) ?? false
+        
+        guard isNotificationEnabled else {
+            return false
+        }
+        
+        // 권한 확인
+        let status = await checkAuthorizationStatus()
+        guard status == .authorized else {
+            print("❌ 알림 권한이 없어 알림을 설정할 수 없습니다.")
+            return false
+        }
+        
+        return true
+    }
+    
+    /// 2단계: 기존 알림 정리
+    private func clearExistingNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+    
+    /// 3단계: 알림 대상 필터링
+    private func filterNotificationTargets(from allTasks: [MetaMartsClosedDays]) async -> [MetaMartsClosedDays] {
+        // 사용자 선택 매장만 필터링
+        let userSelectedTasks = filterUserSelectedTasks(from: allTasks)
+        
+        // 가까운 미래의 휴무일만 필터링
+        let nearFutureTasks = filterNearFutureTasks(from: userSelectedTasks)
+        
+        return nearFutureTasks
+    }
+    
+    /// 4단계: 알림 스케줄링 실행
+    private func scheduleNotificationsForTasks(_ tasks: [MetaMartsClosedDays]) async -> Int {
+        var scheduledCount = 0
+        
+        for task in tasks {
+            for notificationType in NotificationType.allCases {
+                let success = await scheduleNotification(
+                    for: task.taskDate,
+                    type: notificationType,
+                    martType: task.type
+                )
+                if success {
+                    scheduledCount += 1
+                }
+            }
+        }
+        
+        return scheduledCount
+    }
+    
+    /// 5단계: 결과 검증 및 로깅
+    private func validateAndLogResults(scheduledCount: Int) async {
+        // iOS 64개 제한 체크
+        if scheduledCount > Constants.maxSafeNotificationCount {
+            print("⚠️ 알림 개수가 많습니다 (\(scheduledCount)개). iOS 제한으로 일부 알림이 누락될 수 있습니다.")
+        }
+    }
+    
+    /// 사용자가 선택한 매장의 휴무일만 필터링
+    private func filterUserSelectedTasks(from tasks: [MetaMartsClosedDays]) -> [MetaMartsClosedDays] {
+        // UserDefaults에서 사용자 선택 정보 읽기
+        let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
+        let isCostco = userDefaults?.bool(forKey: AppStorageKeys.isCostco) ?? false
+        let selectedBranch = userDefaults?.integer(forKey: AppStorageKeys.selectedBranch) ?? 0
+        
+        return tasks.filter { task in
+            switch task.type {
+            case .normal:
+                // 일반 마트는 코스트코를 선택하지 않았을 때만
+                return !isCostco
+                
+            case .costco(let branch):
+                // 코스트코를 선택했고, 해당 지점과 일치할 때만
+                guard isCostco else { return false }
+                
+                let branchID = branch.branchID
+                return branchID == selectedBranch
+            }
+        }
+    }
+    
+    /// 가까운 미래의 휴무일만 필터링 (앞으로 90일)
+    private func filterNearFutureTasks(from tasks: [MetaMartsClosedDays]) -> [MetaMartsClosedDays] {
+        let today = Date()
+        let futureLimit = Calendar.current.date(byAdding: .day, value: Self.maxNotificationDays, to: today)!
+        
+        return tasks.filter { task in
+            task.taskDate >= today && task.taskDate <= futureLimit
+        }.sorted { $0.taskDate < $1.taskDate }
+    }
+    
+    /// 개별 알림 스케줄링
+    private func scheduleNotification(
+        for closedDate: Date,
+        type: NotificationType,
+        martType: MartType
+    ) async -> Bool {
+        // 알림 날짜 계산
+        guard let notificationDate = Calendar.current.date(
+            byAdding: .day,
+            value: -type.daysToSubtract,
+            to: closedDate
+        ) else {
+            print("❌ 알림 날짜 계산 실패: \(closedDate)")
+            return false
+        }
+        
+        // 알림 시간 설정
+        var dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: notificationDate)
+        dateComponents.hour = Self.notificationHour
+        dateComponents.minute = Self.notificationMinute
+        dateComponents.second = 0
+        
+        guard let finalNotificationDate = Calendar.current.date(from: dateComponents) else {
+            print("❌ 최종 알림 시간 계산 실패")
+            return false
+        }
+        
+        // 과거 시간은 스킵
+        if finalNotificationDate <= Date() {
+            return false
+        }
+        
+        // 알림 콘텐츠 생성
+        let content = UNMutableNotificationContent()
+        content.title = type.title
+        content.body = type.body(for: martType)
+        content.sound = .default
+        
+        // 메타데이터 추가
+        content.categoryIdentifier = "MART_CLOSURE"
+        content.userInfo = [
+            "martType": martType.widgetDisplayName,
+            "closedDate": ISO8601DateFormatter().string(from: closedDate),
+            "notificationType": type.rawValue
+        ]
+        
+        // 트리거 생성
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: dateComponents,
+            repeats: false
+        )
+        
+        // 고유 식별자 생성
+        let identifier = generateIdentifier(
+            for: closedDate,
+            type: type,
+            martType: martType
+        )
+        
+        // 알림 요청 생성 및 등록
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: trigger
+        )
+        
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+            return true
+            
+        } catch {
+            print("❌ 알림 설정 실패: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // MARK: - 유틸리티 메서드
+    
+    /// 알림 식별자 생성
+    private func generateIdentifier(
+        for closedDate: Date,
+        type: NotificationType,
+        martType: MartType
+    ) -> String {
+        let dateString = ISO8601DateFormatter().string(from: closedDate)
+        let martTypeString = martType.widgetDisplayName.replacingOccurrences(of: " ", with: "_")
+        return "mart_\(martTypeString)_\(dateString)_\(type.rawValue)"
+    }
+    
+
+    
+    /// 모든 알림 취소
+    func cancelAllNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+    
+    /// UI 표시용 설정 문자열
+    static var settingsDescription: String {
+        let hour = notificationHour == 12 ? 12 : (notificationHour > 12 ? notificationHour - 12 : notificationHour)
+        let period = notificationHour < 12 ? "오전" : "오후"
+        let timeString = notificationMinute == 0 ? "\(period) \(hour)시" : "\(period) \(hour)시 \(notificationMinute)분"
+        
+        return "휴무일 \(firstNotificationDaysBefore)일 전과 \(secondNotificationDaysBefore)일 전 \(timeString)에 알림 (앞으로 \(maxNotificationDays)일간)"
+    }
+    
+
+}

--- a/DontGoMart/Manager/NotificationManager.swift
+++ b/DontGoMart/Manager/NotificationManager.swift
@@ -22,8 +22,8 @@ final class NotificationManager {
     static var notificationHour: Int = 21
     /// 알림 분
     static var notificationMinute: Int = 0
-    /// 알림 설정할 최대 일수 (앞으로 90일)
-    static let maxNotificationDays: Int = 90
+    /// 알림 설정할 최대 일수 (앞으로 1년)
+    static let maxNotificationDays: Int = 365
     
     // MARK: - 알림 타입
     
@@ -312,7 +312,7 @@ final class NotificationManager {
         let period = notificationHour < 12 ? "오전" : "오후"
         let timeString = notificationMinute == 0 ? "\(period) \(hour)시" : "\(period) \(hour)시 \(notificationMinute)분"
         
-        return "휴무일 \(firstNotificationDaysBefore)일 전과 \(secondNotificationDaysBefore)일 전 \(timeString)에 알림 (앞으로 \(maxNotificationDays)일간)"
+        return "휴무일 \(firstNotificationDaysBefore)일 전과 \(secondNotificationDaysBefore)일 전 \(timeString)에 알림을 받습니다."
     }
     
 

--- a/DontGoMart/Model/MartModel.swift
+++ b/DontGoMart/Model/MartModel.swift
@@ -82,3 +82,26 @@ struct MartHoliday: Hashable, Identifiable {
     let month: Int
     let day: Int
 }
+
+// MARK: - MartType Extensions for Notification
+
+extension MartType {
+    /// 알림용 매장명 (더 구체적인 매장명)
+    var notificationStoreName: String {
+        switch self {
+        case .normal:
+            return "대형마트"
+        case .costco(let branch):
+            switch branch {
+            case .normal:
+                return "코스트코 일반매장"
+            case .daegu:
+                return "코스트코 대구점"
+            case .ilsan:
+                return "코스트코 일산점"
+            case .ulsan:
+                return "코스트코 울산점"
+            }
+        }
+    }
+}

--- a/DontGoMart/Utilities/Utillity.swift
+++ b/DontGoMart/Utilities/Utillity.swift
@@ -20,4 +20,5 @@ enum AppStorageKeys {
     static let isPremium = "isPremium"
     static let widgetHolidayText = "widgetHolidayText"
     static let widgetTwoHolidayText = "widgetTwoHolidayText"
+    static let notificationEnabled = "notificationEnabled"
 }


### PR DESCRIPTION
# 📝 Description

설정한 마트 휴무일 3일전, 1일전 21시에 마트가 하지않는다는 알림을 받는 기능을 구현했습니다.

기존의 코드 일관성을 따르려고 노력했습니다. 

- 기존 코드를 수정하지 않고 extension을 활용했습니다.(일부 view코드는 수정이 불가피했습니다..)
- 매니저 클래스는 기존 WidgetManager를 참고하여 싱글톤으로 구현했습니다.
- Scene 폴더 내부에 있는 파일들이 뷰 + 비지니스로직을 포함했기에 별도로 분리안하고 작성했습니다.
- App파일(진입점)에 앱 실행시 데이터 초기화 로직을 담고 있어서 알림 서비스 초기화 로직도 해당 파일에 추가하였습니다.
- 로깅이나 에러상태, 매직넘버를 별도로 관리하지 않아서 그대로 흐름을 따랐습니다. 즉 하드코딩했습니다.(가독성을 해치긴하지만.. 현재 작업단계에서는 일관되게 하는게 맞다고 생각했습니다. 아직 볼륨이 크지 않기때문?)
- 1년 후까지의 알림을 지원하도록 구현했습니다.

### 왜 1년으로 했나?
앱 내에서는 3년간의 휴무일 데이터를 가지고 있더군요. 근데 이 데이터의 알림을 다 스케줄링을 하는 건 불가능했습니다. ios에서는 최대 64개만 예약할 수 있더라고요.  
```
일반 마트: 월 2회 × 12개월 = 24개 휴무일 → 48개 알림
코스트코: 월 2회 × 12개월 = 24개 휴무일 → 48개 알림
```
이와 같은 이유로 1년을 잡았고, 혹시나 휴무일이 추가 될 경우를 위해 `maxSafeNotificationCount` 변수로 임곗값을 설정해놓았습니다.

그렇다면 1년 뒤에는? 다시 토글을 껐다켜야합니다. -> 개선 필요.

# 🔄 Changes

### Managers/NotificationManager.swift
마트 휴무일 알림 시스템의 핵심 매니저 클래스. 사용자 선택 매장의 휴무일을 미리 알려주는 알림 기능을 제공합니다.

### 주요 설정 값
```swift
static var firstNotificationDaysBefore: Int = 3     // 3일 전 알림
static var secondNotificationDaysBefore: Int = 1    // 1일 전 알림  
static var notificationHour: Int = 21               // 오후 9시
static let maxNotificationDays: Int = 90            // 90일간 설정
```
- 기본 값은 1일, 3일전 오후 9시에 알람을 받도록 설정했습니다. 
- 알림 테스트를 원하신다면 해당 값을 조정하면 됩니다.
- maxNotificationDays는 x일 동안 앱을 접속하지 않아도 알람을 받을 수 있게 하였는데, x일에 해당하는 값입니다.

### 주요 기능
```swift
func setupSmartNotifications(for allTasks: [MetaMartsClosedDays]) async
```
- `사용자 설정 확인` → `기존 알림 정리` → `대상 필터링` → `스케줄링` → `검증` 수행

```swift
private func filterUserSelectedTasks(from tasks: [MetaMartsClosedDays]) -> [MetaMartsClosedDays]
```
- **AppStorage 연동**: 실시간 사용자 설정 반영
- **매장별 분기**: 일반마트 vs 코스트코 각 지점별 정확한 필터링
- **불필요한 알림 차단**: 선택하지 않은 매장 완전 제외

```swift
private func scheduleNotification(for closedDate: Date, type: NotificationType, martType: MartType) async -> Bool
```
- **정확한 시간 계산**: 휴무일 기준 1일/3일 전 계산
- **과거 시간 스킵**: 이미 지난 시간은 자동으로 제외
- **고유 식별자**: 중복 방지를 위한 유니크 ID 생성

```swift
func requestAuthorization() async -> Bool
func checkAuthorizationStatus() async -> UNAuthorizationStatus
```
- 상태별(허용/거부/미결정) 권한 처리


```swift
func body(for martType: MartType) -> String
```
- 매장별 맞춤 알림 메시지 생성


### Scene/SettingView.swift
SettingView에 알림 설정 섹션을 추가하고 휴무일 알림 버튼을 추가하였습니다.

| Before | After | 설명 |
|--------|-------|------|
| <img src="https://github.com/user-attachments/assets/e7fb57fe-27a3-449e-b6be-b06b36472ea6" width="250"> | <img src="https://github.com/user-attachments/assets/5d2a4e3e-bd78-462f-8756-0eb628d4c38d" width="250"> | **알림 설정 섹션 추가**<br>- 휴무일 알림 토글 추가<br>- 설정 설명 동적 표시<br>- 기존 UI 일관성 유지 |

### 주요 기능
```swift
private func handleNotificationToggle() async
```
- 토글 상태 변경의 모든 것을 처리
- **매장 설정과 연동**: 선택한 매장에 맞는 알림만 설정

```swift
private func checkAndSyncNotificationStatus() async
```
- **권한 상태 체크**: 시스템 설정 변경 감지
- **토글 상태 자동 보정**: 권한 없으면 토글 자동 off
- **무결성 보장**: UI 상태와 실제 권한 상태 일치

# 🧪 Test

| <img src="https://github.com/user-attachments/assets/b1db77bf-6366-400f-91f1-f06de6bd21c0" width="300"> | <img src="https://github.com/user-attachments/assets/17f5ef3e-3994-4f0b-84d3-795d405e59a2" width="300"> |
|:-----------:|:-----------:|
| **알림 기능 Flow** | **알림 거부 상태 Flow** |
| 백그라운드 앱 정상 작동 확인<br>포그라운드에서는 알림이 오지 않습니다<br>날짜를 임의로 조작해서 한 테스트 영상입니다 | 알림 설정 Off시 토글 스위칭 불가<br>설정 안내 팝업 제공<br>설정 완료시 토글 스위칭 가능 |

# 🙋🏻별도의 코멘트..
1. 보통은 앱 최초 실행 시 권한을 요구하는데, 찾아보니 ios에서는 해당 기능 실행을 요구할 때 권한 요청을 권장한다고 나와있더라고요. 그래서 알림 토글을 건드릴 떄 권한을 요청하도록 했습니다. 이에 관하여 피드백 할 점이 있는지?
2. 벼락치기 하느라 바이브 코딩했습니다 하하. 리팩토링이나 로직 개선 점이 보이면 말씀해주시면 수정하겠습니다. 
3. 중요하다고 생각되는 것만 PR에 작성하였으나 내용에 추가할 점이 있다면 말씀해주세요.