### PR TITLE
fix: NotificationManager 참조 에러 해결

### DIFF
--- a/DontGoMart.xcodeproj/project.pbxproj
+++ b/DontGoMart.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		C3E71D7C2D2BFBBF00F4A24B /* Utillity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */; };
 		C3E71D7D2D2BFBBF00F4A24B /* Utillity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */; };
 		C3F7E7342D2CACF5003B7762 /* WidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */; };
+		D1C229962E0C2AC000969839 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C229952E0C2ABB00969839 /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 		C3C2F8EE2CEB4952003ED9A5 /* DontGoMartTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DontGoMartTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utillity.swift; sourceTree = "<group>"; };
 		C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetManager.swift; sourceTree = "<group>"; };
+		D1C229952E0C2ABB00969839 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -157,6 +159,7 @@
 		58446A242A5938F0001CC9D1 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				D1C229952E0C2ABB00969839 /* NotificationManager.swift */,
 				589D5F482A433EFD00DB3CCF /* StoreKitManager.swift */,
 				C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */,
 			);
@@ -454,6 +457,7 @@
 				C359F4F02CFD724000F26B1D /* WidgetEntry.swift in Sources */,
 				C359F5092CFDC16300F26B1D /* TwoHolidayWidgetProvider.swift in Sources */,
 				58B693F32A3B59EF00FF904B /* CalendarWidget.intentdefinition in Sources */,
+				D1C229962E0C2AC000969839 /* NotificationManager.swift in Sources */,
 				C3E71D7C2D2BFBBF00F4A24B /* Utillity.swift in Sources */,
 				58B693D02A3B56E800FF904B /* DontGoMartApp.swift in Sources */,
 				58D40AD52CDF8E68008C6458 /* DateValue.swift in Sources */,

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -76,12 +76,13 @@ struct DontGoMartApp: App {
         
         let status = await notificationManager.checkAuthorizationStatus()
         
-        if status == .authorized {
+        switch status {
+        case .authorized:
             await notificationManager.setupSmartNotifications(for: tasks)
-        } else if status == .notDetermined {
-            print("⏳ 알림 권한이 결정되지 않았습니다. 설정에서 알림을 활성화해주세요.")
-        } else {
-            print("❌ 알림 권한이 거부되었습니다. 설정에서 권한을 허용해주세요.")
+        case .notDetermined:
+            break
+        default:
+            break
         }
     }
 

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -55,7 +55,38 @@ struct DontGoMartApp: App {
                         martType: .costco(type: .ulsan)
                     ))
                     WidgetManager.shared.updateWidget()
+                    
+                    Task {
+                        await setupSmartNotifications()
+                    }
                 }
+        }
+    }
+    
+    /// 스마트 알림 초기 설정 (사용자 설정 고려)
+    private func setupSmartNotifications() async {
+        let notificationManager = NotificationManager.shared
+        
+        // 사용자가 알림을 활성화했는지 확인
+        let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
+        let isNotificationEnabled = userDefaults?.bool(forKey: AppStorageKeys.notificationEnabled) ?? false
+        
+        guard isNotificationEnabled else {
+            print("🔕 사용자가 알림을 비활성화했으므로 알림을 설정하지 않습니다.")
+            return
+        }
+        
+        // 권한 상태 확인
+        let status = await notificationManager.checkAuthorizationStatus()
+        
+        if status == .authorized {
+            // 이미 권한이 있으면 바로 알림 설정
+            await notificationManager.setupSmartNotifications(for: tasks)
+        } else if status == .notDetermined {
+            // 권한이 결정되지 않았으면 요청 (사용자가 직접 설정에서 켤 때까지 대기)
+            print("⏳ 알림 권한이 결정되지 않았습니다. 설정에서 알림을 활성화해주세요.")
+        } else {
+            print("❌ 알림 권한이 거부되었습니다. 설정에서 권한을 허용해주세요.")
         }
     }
 

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -62,9 +62,7 @@ struct DontGoMartApp: App {
                 }
         }
     }
-    
-    // MARK: - Private Methods
-    
+        
     private func setupSmartNotifications() async {
         let notificationManager = NotificationManager.shared
         

--- a/DontGoMart/DontGoMartApp.swift
+++ b/DontGoMart/DontGoMartApp.swift
@@ -69,10 +69,7 @@ struct DontGoMartApp: App {
         let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
         let isNotificationEnabled = userDefaults?.bool(forKey: AppStorageKeys.notificationEnabled) ?? false
         
-        guard isNotificationEnabled else {
-            print("🔕 사용자가 알림을 비활성화했으므로 알림을 설정하지 않습니다.")
-            return
-        }
+        guard isNotificationEnabled else { return }
         
         let status = await notificationManager.checkAuthorizationStatus()
         

--- a/DontGoMart/Manager/NotificationManager.swift
+++ b/DontGoMart/Manager/NotificationManager.swift
@@ -17,13 +17,13 @@ final class NotificationManager {
     // MARK: - Configuration Properties
     
     /// 첫 번째 알림: 며칠 전에 보낼지 (기본: 3일 전)
-    static var firstNotificationDaysBefore: Int = 3
+    static let firstNotificationDaysBefore: Int = 3
     /// 두 번째 알림: 며칠 전에 보낼지 (기본: 1일 전)
-    static var secondNotificationDaysBefore: Int = 1
+    static let secondNotificationDaysBefore: Int = 1
     /// 알림 시간: 시 (24시간 형식)
-    static var notificationHour: Int = 21
+    static let notificationHour: Int = 21
     /// 알림 분
-    static var notificationMinute: Int = 0
+    static let notificationMinute: Int = 0
     
     // MARK: - Notification Types
     

--- a/DontGoMart/Manager/NotificationManager.swift
+++ b/DontGoMart/Manager/NotificationManager.swift
@@ -4,9 +4,7 @@ import UserNotifications
 final class NotificationManager {
     static let shared = NotificationManager()
     private init() {}
-    
-    // MARK: - Constants
-    
+        
     private enum Constants {
         /// iOS 알림 제한 안전 임계값 (실제 제한: 64개)
         static let maxSafeNotificationCount = 60

--- a/DontGoMart/Manager/NotificationManager.swift
+++ b/DontGoMart/Manager/NotificationManager.swift
@@ -1,0 +1,319 @@
+import SwiftUI
+import UserNotifications
+
+final class NotificationManager {
+    static let shared = NotificationManager()
+    private init() {}
+    
+    // MARK: - 상수 정의
+    
+    private enum Constants {
+        /// iOS 알림 제한 안전 임계값 (실제 제한: 64개)
+        static let maxSafeNotificationCount = 60
+    }
+    
+    // MARK: - 알림 설정 변수들
+    
+    /// 첫 번째 알림: 며칠 전에 보낼지 (기본: 3일 전)
+    static var firstNotificationDaysBefore: Int = 3
+    /// 두 번째 알림: 며칠 전에 보낼지 (기본: 1일 전)
+    static var secondNotificationDaysBefore: Int = 1
+    /// 알림 시간: 시 (24시간 형식)
+    static var notificationHour: Int = 21
+    /// 알림 분
+    static var notificationMinute: Int = 0
+    /// 알림 설정할 최대 일수 (앞으로 90일)
+    static let maxNotificationDays: Int = 90
+    
+    // MARK: - 알림 타입
+    
+    enum NotificationType: String, CaseIterable {
+        case firstNotification = "day1_before"
+        case secondNotification = "day2_before"
+        
+        var title: String {
+            switch self {
+            case .firstNotification:
+                return "마트 휴무일 안내"
+            case .secondNotification:
+                return "마트 휴무일 안내"
+            }
+        }
+        
+        func body(for martType: MartType) -> String {
+            let storeName = martType.notificationStoreName
+            switch self {
+            case .firstNotification:
+                return "\(NotificationManager.firstNotificationDaysBefore)일 뒤 \(storeName) 휴점일입니다."
+            case .secondNotification:
+                return "\(NotificationManager.secondNotificationDaysBefore)일 뒤 \(storeName) 휴점일입니다."
+            }
+        }
+        
+        var daysToSubtract: Int {
+            switch self {
+            case .firstNotification:
+                return NotificationManager.firstNotificationDaysBefore
+            case .secondNotification:
+                return NotificationManager.secondNotificationDaysBefore
+            }
+        }
+    }
+    
+    // MARK: - 권한 관리
+    
+    /// 알림 권한 요청
+    func requestAuthorization() async -> Bool {
+        do {
+            let authorized = try await UNUserNotificationCenter.current().requestAuthorization(
+                options: [.alert, .sound, .badge]
+            )
+            
+            if authorized {
+                print("✅ 알림 권한이 허용되었습니다.")
+            } else {
+                print("❌ 알림 권한이 거부되었습니다.")
+            }
+            
+            return authorized
+        } catch {
+            print("❌ 알림 권한 요청 중 오류: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    /// 현재 알림 권한 상태 확인
+    func checkAuthorizationStatus() async -> UNAuthorizationStatus {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        return settings.authorizationStatus
+    }
+    
+
+    
+    // MARK: - 핵심 알림 설정 로직
+    
+    /// 사용자 선택 매장의 가까운 미래 휴무일에 대해서만 알림 설정 (iOS 64개 제한 고려)
+    func setupSmartNotifications(for allTasks: [MetaMartsClosedDays]) async {
+        
+        // 1. 사전 조건 확인
+        guard await validateNotificationPrerequisites() else { return }
+        
+        // 2. 기존 알림 정리
+        clearExistingNotifications()
+        
+        // 3. 알림 대상 필터링
+        let targetTasks = await filterNotificationTargets(from: allTasks)
+        
+        // 4. 알림 스케줄링 실행
+        let scheduledCount = await scheduleNotificationsForTasks(targetTasks)
+        
+        // 5. 결과 검증 및 로깅
+        await validateAndLogResults(scheduledCount: scheduledCount)
+    }
+    
+    // MARK: - 알림 설정 단계별 메서드
+    
+    /// 1단계: 알림 설정 사전 조건 확인
+    private func validateNotificationPrerequisites() async -> Bool {
+        // 사용자 알림 설정 확인
+        let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
+        let isNotificationEnabled = userDefaults?.bool(forKey: AppStorageKeys.notificationEnabled) ?? false
+        
+        guard isNotificationEnabled else {
+            return false
+        }
+        
+        // 권한 확인
+        let status = await checkAuthorizationStatus()
+        guard status == .authorized else {
+            print("❌ 알림 권한이 없어 알림을 설정할 수 없습니다.")
+            return false
+        }
+        
+        return true
+    }
+    
+    /// 2단계: 기존 알림 정리
+    private func clearExistingNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+    
+    /// 3단계: 알림 대상 필터링
+    private func filterNotificationTargets(from allTasks: [MetaMartsClosedDays]) async -> [MetaMartsClosedDays] {
+        // 사용자 선택 매장만 필터링
+        let userSelectedTasks = filterUserSelectedTasks(from: allTasks)
+        
+        // 가까운 미래의 휴무일만 필터링
+        let nearFutureTasks = filterNearFutureTasks(from: userSelectedTasks)
+        
+        return nearFutureTasks
+    }
+    
+    /// 4단계: 알림 스케줄링 실행
+    private func scheduleNotificationsForTasks(_ tasks: [MetaMartsClosedDays]) async -> Int {
+        var scheduledCount = 0
+        
+        for task in tasks {
+            for notificationType in NotificationType.allCases {
+                let success = await scheduleNotification(
+                    for: task.taskDate,
+                    type: notificationType,
+                    martType: task.type
+                )
+                if success {
+                    scheduledCount += 1
+                }
+            }
+        }
+        
+        return scheduledCount
+    }
+    
+    /// 5단계: 결과 검증 및 로깅
+    private func validateAndLogResults(scheduledCount: Int) async {
+        // iOS 64개 제한 체크
+        if scheduledCount > Constants.maxSafeNotificationCount {
+            print("⚠️ 알림 개수가 많습니다 (\(scheduledCount)개). iOS 제한으로 일부 알림이 누락될 수 있습니다.")
+        }
+    }
+    
+    /// 사용자가 선택한 매장의 휴무일만 필터링
+    private func filterUserSelectedTasks(from tasks: [MetaMartsClosedDays]) -> [MetaMartsClosedDays] {
+        // UserDefaults에서 사용자 선택 정보 읽기
+        let userDefaults = UserDefaults(suiteName: Utillity.appGroupId)
+        let isCostco = userDefaults?.bool(forKey: AppStorageKeys.isCostco) ?? false
+        let selectedBranch = userDefaults?.integer(forKey: AppStorageKeys.selectedBranch) ?? 0
+        
+        return tasks.filter { task in
+            switch task.type {
+            case .normal:
+                // 일반 마트는 코스트코를 선택하지 않았을 때만
+                return !isCostco
+                
+            case .costco(let branch):
+                // 코스트코를 선택했고, 해당 지점과 일치할 때만
+                guard isCostco else { return false }
+                
+                let branchID = branch.branchID
+                return branchID == selectedBranch
+            }
+        }
+    }
+    
+    /// 가까운 미래의 휴무일만 필터링 (앞으로 90일)
+    private func filterNearFutureTasks(from tasks: [MetaMartsClosedDays]) -> [MetaMartsClosedDays] {
+        let today = Date()
+        let futureLimit = Calendar.current.date(byAdding: .day, value: Self.maxNotificationDays, to: today)!
+        
+        return tasks.filter { task in
+            task.taskDate >= today && task.taskDate <= futureLimit
+        }.sorted { $0.taskDate < $1.taskDate }
+    }
+    
+    /// 개별 알림 스케줄링
+    private func scheduleNotification(
+        for closedDate: Date,
+        type: NotificationType,
+        martType: MartType
+    ) async -> Bool {
+        // 알림 날짜 계산
+        guard let notificationDate = Calendar.current.date(
+            byAdding: .day,
+            value: -type.daysToSubtract,
+            to: closedDate
+        ) else {
+            print("❌ 알림 날짜 계산 실패: \(closedDate)")
+            return false
+        }
+        
+        // 알림 시간 설정
+        var dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: notificationDate)
+        dateComponents.hour = Self.notificationHour
+        dateComponents.minute = Self.notificationMinute
+        dateComponents.second = 0
+        
+        guard let finalNotificationDate = Calendar.current.date(from: dateComponents) else {
+            print("❌ 최종 알림 시간 계산 실패")
+            return false
+        }
+        
+        // 과거 시간은 스킵
+        if finalNotificationDate <= Date() {
+            return false
+        }
+        
+        // 알림 콘텐츠 생성
+        let content = UNMutableNotificationContent()
+        content.title = type.title
+        content.body = type.body(for: martType)
+        content.sound = .default
+        
+        // 메타데이터 추가
+        content.categoryIdentifier = "MART_CLOSURE"
+        content.userInfo = [
+            "martType": martType.widgetDisplayName,
+            "closedDate": ISO8601DateFormatter().string(from: closedDate),
+            "notificationType": type.rawValue
+        ]
+        
+        // 트리거 생성
+        let trigger = UNCalendarNotificationTrigger(
+            dateMatching: dateComponents,
+            repeats: false
+        )
+        
+        // 고유 식별자 생성
+        let identifier = generateIdentifier(
+            for: closedDate,
+            type: type,
+            martType: martType
+        )
+        
+        // 알림 요청 생성 및 등록
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: trigger
+        )
+        
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+            return true
+            
+        } catch {
+            print("❌ 알림 설정 실패: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // MARK: - 유틸리티 메서드
+    
+    /// 알림 식별자 생성
+    private func generateIdentifier(
+        for closedDate: Date,
+        type: NotificationType,
+        martType: MartType
+    ) -> String {
+        let dateString = ISO8601DateFormatter().string(from: closedDate)
+        let martTypeString = martType.widgetDisplayName.replacingOccurrences(of: " ", with: "_")
+        return "mart_\(martTypeString)_\(dateString)_\(type.rawValue)"
+    }
+    
+
+    
+    /// 모든 알림 취소
+    func cancelAllNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+    
+    /// UI 표시용 설정 문자열
+    static var settingsDescription: String {
+        let hour = notificationHour == 12 ? 12 : (notificationHour > 12 ? notificationHour - 12 : notificationHour)
+        let period = notificationHour < 12 ? "오전" : "오후"
+        let timeString = notificationMinute == 0 ? "\(period) \(hour)시" : "\(period) \(hour)시 \(notificationMinute)분"
+        
+        return "휴무일 \(firstNotificationDaysBefore)일 전과 \(secondNotificationDaysBefore)일 전 \(timeString)에 알림 (앞으로 \(maxNotificationDays)일간)"
+    }
+    
+
+}

--- a/DontGoMart/Manager/NotificationManager.swift
+++ b/DontGoMart/Manager/NotificationManager.swift
@@ -22,8 +22,8 @@ final class NotificationManager {
     static var notificationHour: Int = 21
     /// 알림 분
     static var notificationMinute: Int = 0
-    /// 알림 설정할 최대 일수 (앞으로 90일)
-    static let maxNotificationDays: Int = 90
+    /// 알림 설정할 최대 일수 (앞으로 1년)
+    static let maxNotificationDays: Int = 365
     
     // MARK: - 알림 타입
     
@@ -312,7 +312,7 @@ final class NotificationManager {
         let period = notificationHour < 12 ? "오전" : "오후"
         let timeString = notificationMinute == 0 ? "\(period) \(hour)시" : "\(period) \(hour)시 \(notificationMinute)분"
         
-        return "휴무일 \(firstNotificationDaysBefore)일 전과 \(secondNotificationDaysBefore)일 전 \(timeString)에 알림 (앞으로 \(maxNotificationDays)일간)"
+        return "휴무일 \(firstNotificationDaysBefore)일 전과 \(secondNotificationDaysBefore)일 전 \(timeString)에 알림을 받습니다."
     }
     
 

--- a/DontGoMart/Model/MartModel.swift
+++ b/DontGoMart/Model/MartModel.swift
@@ -14,12 +14,30 @@ enum MartType: Hashable {
     case normal
     case costco(type: CostcoBranch)
     
-    var widgetDisplayName : String {
+    var widgetDisplayName: String {
         switch self {
-        case .normal :
+        case .normal:
             return "마트"
-        case .costco :
+        case .costco:
             return "코스트코"
+        }
+    }
+    
+    var notificationStoreName: String {
+        switch self {
+        case .normal:
+            return "대형마트"
+        case .costco(let branch):
+            switch branch {
+            case .normal:
+                return "코스트코 일반매장"
+            case .daegu:
+                return "코스트코 대구점"
+            case .ilsan:
+                return "코스트코 일산점"
+            case .ulsan:
+                return "코스트코 울산점"
+            }
         }
     }
 }
@@ -81,27 +99,4 @@ struct MartHoliday: Hashable, Identifiable {
     let type: MartType
     let month: Int
     let day: Int
-}
-
-// MARK: - MartType Extensions for Notification
-
-extension MartType {
-    /// 알림용 매장명 (더 구체적인 매장명)
-    var notificationStoreName: String {
-        switch self {
-        case .normal:
-            return "대형마트"
-        case .costco(let branch):
-            switch branch {
-            case .normal:
-                return "코스트코 일반매장"
-            case .daegu:
-                return "코스트코 대구점"
-            case .ilsan:
-                return "코스트코 일산점"
-            case .ulsan:
-                return "코스트코 울산점"
-            }
-        }
-    }
 }

--- a/DontGoMart/Model/MartModel.swift
+++ b/DontGoMart/Model/MartModel.swift
@@ -82,3 +82,26 @@ struct MartHoliday: Hashable, Identifiable {
     let month: Int
     let day: Int
 }
+
+// MARK: - MartType Extensions for Notification
+
+extension MartType {
+    /// 알림용 매장명 (더 구체적인 매장명)
+    var notificationStoreName: String {
+        switch self {
+        case .normal:
+            return "대형마트"
+        case .costco(let branch):
+            switch branch {
+            case .normal:
+                return "코스트코 일반매장"
+            case .daegu:
+                return "코스트코 대구점"
+            case .ilsan:
+                return "코스트코 일산점"
+            case .ulsan:
+                return "코스트코 울산점"
+            }
+        }
+    }
+}

--- a/DontGoMart/Screen/SettingsView.swift
+++ b/DontGoMart/Screen/SettingsView.swift
@@ -20,7 +20,6 @@ struct StoreTip: Tip {
     }
 }
 
-
 struct SettingsView: View {
     @Binding var isShowingSettings: Bool
     @AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
@@ -41,7 +40,6 @@ struct SettingsView: View {
                         selectedBranch = isCostco ? 1 : 0
                         WidgetManager.shared.updateWidget()
                         
-                        // 마트 설정 변경 시 알림도 다시 설정
                         Task {
                             await handleNotificationToggle()
                         }
@@ -80,7 +78,6 @@ struct SettingsView: View {
                 }
             }
             .onAppear {
-                // 뷰가 나타날 때 알림 상태 동기화
                 Task {
                     await checkAndSyncNotificationStatus()
                 }
@@ -91,33 +88,27 @@ struct SettingsView: View {
         }
     }
     
-    // MARK: - 알림 관련 메서드
+    // MARK: - Private Methods
     
-    /// 알림 토글 상태 변경 처리
     private func handleNotificationToggle() async {
         if isNotificationEnabled {
-            // 알림 켜기: 권한 요청 후 알림 설정
             let status = await notificationManager.checkAuthorizationStatus()
             
             if status == .authorized {
-                // 이미 권한이 있으면 바로 알림 설정
-                    await notificationManager.setupSmartNotifications(for: tasks)
-                    print("✅ [SettingsView] 알림이 활성화되었습니다.")
+                await notificationManager.setupSmartNotifications(for: tasks)
+                print("✅ [SettingsView] 알림이 활성화되었습니다.")
             } else if status == .denied {
-                // 이미 권한이 거부된 상태면 토글 다시 끄기
                 DispatchQueue.main.async {
                     self.isNotificationEnabled = false
                     self.showingPermissionAlert = true
                 }
                 print("❌ [SettingsView] 알림 권한이 거부된 상태입니다.")
             } else {
-                // 권한이 미결정 상태면 권한 요청
                 let authorized = await notificationManager.requestAuthorization()
                 if authorized {
                     await notificationManager.setupSmartNotifications(for: tasks)
                     print("✅ [SettingsView] 알림 권한 허용 후 알림이 활성화되었습니다.")
                 } else {
-                    // 권한이 거부되면 토글 다시 끄기
                     DispatchQueue.main.async {
                         self.isNotificationEnabled = false
                         self.showingPermissionAlert = true
@@ -126,17 +117,14 @@ struct SettingsView: View {
                 }
             }
         } else {
-            // 알림 끄기: 모든 알림 취소
             notificationManager.cancelAllNotifications()
             print("🔕 [SettingsView] 알림이 비활성화되었습니다.")
         }
     }
     
-    /// 앱 시작 시 알림 상태 확인 및 동기화
     private func checkAndSyncNotificationStatus() async {
         let status = await notificationManager.checkAuthorizationStatus()
         
-        // 권한이 거부되었거나 없으면 토글을 off로 설정
         if status == .denied || status == .notDetermined {
             if isNotificationEnabled {
                 DispatchQueue.main.async {
@@ -145,15 +133,11 @@ struct SettingsView: View {
             }
         }
         
-        // 토글이 켜져 있고 권한이 있으면 알림 설정 확인
         if isNotificationEnabled && status == .authorized {
             await notificationManager.setupSmartNotifications(for: tasks)
         }
     }
-    
-
 }
-
 
 struct CostcoSettings: View {
     @AppStorage(AppStorageKeys.selectedBranch, store: UserDefaults(suiteName: Utillity.appGroupId)) var selectedBranch: Int = 0
@@ -165,7 +149,6 @@ struct CostcoSettings: View {
     @State private var isUlsanSelected = false
     @State private var isTipShowing = false
     var storeTip = StoreTip()
-    
     
     var body: some View {
         VStack {
@@ -197,7 +180,6 @@ struct CostcoSettings: View {
                     }
                 }
                 
-                
                 Toggle("대구 지점", isOn: Binding(
                     get: { isDaeguSelected },
                     set: { _ in updateSelection(for: .daegu) }
@@ -227,21 +209,20 @@ struct CostcoSettings: View {
     }
     
     private func updateSelection(for branch: CostcoBranch) {
-            // 다른 선택지를 초기화하고 현재 선택지를 저장
-            resetAllSelections()
-            selectedCostcoBranch = branch
-            selectedBranch = branch.branchID
-            
-            switch branch {
-            case .normal:
-                isNormalSelected = true
-            case .daegu:
-                isDaeguSelected = true
-            case .ilsan:
-                isIlsanSelected = true
-            case .ulsan:
-                isUlsanSelected = true
-            }
+        resetAllSelections()
+        selectedCostcoBranch = branch
+        selectedBranch = branch.branchID
+        
+        switch branch {
+        case .normal:
+            isNormalSelected = true
+        case .daegu:
+            isDaeguSelected = true
+        case .ilsan:
+            isIlsanSelected = true
+        case .ulsan:
+            isUlsanSelected = true
+        }
     }
     
     private func resetAllSelections() {
@@ -267,9 +248,7 @@ struct CostcoSettings: View {
     }
 }
 
-
-
-// MARK: - 알림 권한 안내 서브뷰
+// MARK: - Notification Permission Alert
 
 struct NotificationPermissionAlert: View {
     @Binding var isPresented: Bool
@@ -286,7 +265,6 @@ struct NotificationPermissionAlert: View {
             }
     }
     
-    /// 설정 앱으로 이동
     private func openAppSettings() {
         if let settingsUrl = URL(string: UIApplication.openSettingsURLString) {
             UIApplication.shared.open(settingsUrl)

--- a/DontGoMart/Utilities/Utillity.swift
+++ b/DontGoMart/Utilities/Utillity.swift
@@ -20,4 +20,5 @@ enum AppStorageKeys {
     static let isPremium = "isPremium"
     static let widgetHolidayText = "widgetHolidayText"
     static let widgetTwoHolidayText = "widgetTwoHolidayText"
+    static let notificationEnabled = "notificationEnabled"
 }


### PR DESCRIPTION
# Bug Description
프로젝트를 클론했을 때 NotificationManager.swift 파일을 Xcode에서 인식하지 못하는 문제가 발생했습니다.

## 원인
project.pbxproj 파일에서 NotificationManager.swift에 대한 참조가 중복으로 존재한 것을 확인할 수 있었습니다. 
로컬에서 관리하던 파일과 버전이 다른 것이 올라갔습니다.
```
기존 참조: D10D98BA2E056F72009C3EA1
새 참조:   D1C229952E0C2ABB00969839
```

## 수정 사항 및 체크리스트
- [x] project.pbxproj 파일에서 중복 참조 제거
- [x] NotificationManager.swift 파일 참조 정리
- [x] 빌드 및 동작 확인

### 코멘트
클론해서 빌드 정상작동 확인했는데 혹시나 한번 받아보고 머지해주시면 감사하겠습니다!!