### PR TITLE
fix: NotificationManager 참조 에러 해결

### DIFF
--- a/DontGoMart.xcodeproj/project.pbxproj
+++ b/DontGoMart.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		C3E71D7C2D2BFBBF00F4A24B /* Utillity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */; };
 		C3E71D7D2D2BFBBF00F4A24B /* Utillity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */; };
 		C3F7E7342D2CACF5003B7762 /* WidgetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */; };
+		D1C229962E0C2AC000969839 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C229952E0C2ABB00969839 /* NotificationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 		C3C2F8EE2CEB4952003ED9A5 /* DontGoMartTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DontGoMartTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C3E71D7B2D2BFBB000F4A24B /* Utillity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utillity.swift; sourceTree = "<group>"; };
 		C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetManager.swift; sourceTree = "<group>"; };
+		D1C229952E0C2ABB00969839 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -157,6 +159,7 @@
 		58446A242A5938F0001CC9D1 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				D1C229952E0C2ABB00969839 /* NotificationManager.swift */,
 				589D5F482A433EFD00DB3CCF /* StoreKitManager.swift */,
 				C3F7E7332D2CACF5003B7762 /* WidgetManager.swift */,
 			);
@@ -454,6 +457,7 @@
 				C359F4F02CFD724000F26B1D /* WidgetEntry.swift in Sources */,
 				C359F5092CFDC16300F26B1D /* TwoHolidayWidgetProvider.swift in Sources */,
 				58B693F32A3B59EF00FF904B /* CalendarWidget.intentdefinition in Sources */,
+				D1C229962E0C2AC000969839 /* NotificationManager.swift in Sources */,
 				C3E71D7C2D2BFBBF00F4A24B /* Utillity.swift in Sources */,
 				58B693D02A3B56E800FF904B /* DontGoMartApp.swift in Sources */,
 				58D40AD52CDF8E68008C6458 /* DateValue.swift in Sources */,


### PR DESCRIPTION
# Bug Description
프로젝트를 클론했을 때 NotificationManager.swift 파일을 Xcode에서 인식하지 못하는 문제가 발생했습니다.

## 원인
project.pbxproj 파일에서 NotificationManager.swift에 대한 참조가 중복으로 존재한 것을 확인할 수 있었습니다. 
로컬에서 관리하던 파일과 버전이 다른 것이 올라갔습니다.

```
기존 참조: D10D98BA2E056F72009C3EA1
새 참조:   D1C229952E0C2ABB00969839
```

## 수정 사항 및 체크리스트
- [x] project.pbxproj 파일에서 중복 참조 제거
- [x] NotificationManager.swift 파일 참조 정리
- [x] 빌드 및 동작 확인

### 코멘트
base branch develop 확인했습니다..